### PR TITLE
Add Standard Plan Only text beside Daily Loss limits

### DIFF
--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -535,16 +535,16 @@ const Rules = () => {
                       </span>
                     </div>
                     <div className="flex justify-between items-start py-2 border-b border-border/30">
-                      <span className="text-sm text-muted-foreground">
-                        Daily Loss Limit
-                      </span>
-                      <span className="flex flex-col items-end leading-tight">
-                        <span className="font-semibold text-foreground">
-                          {account.dailyLoss}
-                        </span>
+                      <span className="flex flex-col leading-tight">
                         <span className="text-sm text-muted-foreground">
-                          Standard Plan Only
+                          Daily Loss Limit
                         </span>
+                        <span className="text-xs text-muted-foreground">
+                          (Standard Plan Only)
+                        </span>
+                      </span>
+                      <span className="font-semibold text-foreground">
+                        {account.dailyLoss}
                       </span>
                     </div>
                     <div className="flex justify-between items-center py-2">

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -534,7 +534,7 @@ const Rules = () => {
                         {account.builderMaxDrawdown}
                       </span>
                     </div>
-                    <div className="flex justify-between items-start py-2 border-b border-border/30">
+                    <div className="flex justify-between items-start gap-3 py-2 border-b border-border/30">
                       <span className="flex flex-col leading-tight">
                         <span className="text-sm text-muted-foreground">
                           Daily Loss Limit

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -534,12 +534,17 @@ const Rules = () => {
                         {account.builderMaxDrawdown}
                       </span>
                     </div>
-                    <div className="flex justify-between items-center py-2 border-b border-border/30">
+                    <div className="flex justify-between items-start py-2 border-b border-border/30">
                       <span className="text-sm text-muted-foreground">
                         Daily Loss Limit
                       </span>
-                      <span className="font-semibold text-foreground">
-                        {account.dailyLoss}
+                      <span className="flex flex-col items-end leading-tight">
+                        <span className="font-semibold text-foreground">
+                          {account.dailyLoss}
+                        </span>
+                        <span className="text-sm text-muted-foreground">
+                          Standard Plan Only
+                        </span>
                       </span>
                     </div>
                     <div className="flex justify-between items-center py-2">

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -534,7 +534,7 @@ const Rules = () => {
                         {account.builderMaxDrawdown}
                       </span>
                     </div>
-                    <div className="flex justify-between items-start gap-3 py-2 border-b border-border/30">
+                    <div className="flex justify-between items-start py-2 border-b border-border/30">
                       <span className="flex flex-col leading-tight">
                         <span className="text-sm text-muted-foreground">
                           Daily Loss Limit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Applied `(Standard Plan Only)` in a single consistent location for every card: directly under `Daily Loss Limit`.
- Preserved each account's specific numeric values.
- Removed visual clutter by keeping the statement only in that one row location.
- No additional copy added anywhere else.

## Validation
- Verified all four account cards render with identical structure and styling, differing only by account-specific values.

## Updated Image
[Account-specific rules cards with a single Standard Plan Only note under Daily Loss Limit in each card](https://cursor.com/agents/bc-be7b389f-4f08-4424-9106-da87e5b0412e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fstandard-plan-only-clean-all-boxes.png)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be7b389f-4f08-4424-9106-da87e5b0412e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be7b389f-4f08-4424-9106-da87e5b0412e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

