### PR TITLE
Update pricing page plan icons to new shield, helmet, and world-holder assets

### DIFF
--- a/src/assets/pricing-icons/advanced-plan-spartan-helmet.svg
+++ b/src/assets/pricing-icons/advanced-plan-spartan-helmet.svg
@@ -1,0 +1,64 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="helmet-gold" x1="32" y1="28" x2="216" y2="224" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE68A" />
+      <stop offset="0.45" stop-color="#FBBF24" />
+      <stop offset="1" stop-color="#92400E" />
+    </linearGradient>
+    <linearGradient id="helmet-gold-soft" x1="56" y1="48" x2="210" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FEF3C7" />
+      <stop offset="0.5" stop-color="#FCD34D" />
+      <stop offset="1" stop-color="#A16207" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M62 142C62 86 104 44 162 44C186 44 208 51 224 63C211 66 200 71 190 79C179 87 171 98 166 112L162 125V180L145 212L116 196L112 136C111 122 100 111 86 111C77 111 70 115 64 121C62 128 62 135 62 142Z"
+    stroke="url(#helmet-gold)"
+    stroke-width="11"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M70 132C98 120 132 96 160 70"
+    stroke="url(#helmet-gold-soft)"
+    stroke-width="9"
+    stroke-linecap="round"
+  />
+  <path
+    d="M160 70C187 80 204 100 206 128"
+    stroke="url(#helmet-gold-soft)"
+    stroke-width="9"
+    stroke-linecap="round"
+  />
+  <path
+    d="M58 146C80 140 99 136 116 136"
+    stroke="url(#helmet-gold)"
+    stroke-width="8"
+    stroke-linecap="round"
+  />
+  <path
+    d="M162 126V178C162 190 158 202 151 212"
+    stroke="url(#helmet-gold-soft)"
+    stroke-width="8"
+    stroke-linecap="round"
+  />
+  <path
+    d="M104 52L84 26L110 36L134 20L160 34L182 24L168 44"
+    stroke="url(#helmet-gold)"
+    stroke-width="8"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M88 31L80 43M102 35L92 50M118 30L108 47M136 29L130 46M152 33L148 51M166 37L168 54"
+    stroke="url(#helmet-gold-soft)"
+    stroke-width="5"
+    stroke-linecap="round"
+  />
+  <path
+    d="M108 152C116 145 127 141 138 141"
+    stroke="url(#helmet-gold-soft)"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+</svg>

--- a/src/assets/pricing-icons/builder-plan-world-holder.svg
+++ b/src/assets/pricing-icons/builder-plan-world-holder.svg
@@ -1,0 +1,32 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="atlas-gold" x1="28" y1="18" x2="226" y2="238" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FEF3C7" />
+      <stop offset="0.52" stop-color="#F59E0B" />
+      <stop offset="1" stop-color="#854D0E" />
+    </linearGradient>
+    <linearGradient id="atlas-gold-soft" x1="38" y1="34" x2="212" y2="220" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE68A" />
+      <stop offset="0.5" stop-color="#FBBF24" />
+      <stop offset="1" stop-color="#A16207" />
+    </linearGradient>
+  </defs>
+
+  <circle cx="136" cy="74" r="58" stroke="url(#atlas-gold)" stroke-width="10" />
+  <path d="M78 74H194M83 53H189M83 95H189" stroke="url(#atlas-gold-soft)" stroke-width="6" stroke-linecap="round" />
+  <path d="M136 16V132M112 20C122 36 128 54 128 74C128 94 122 112 112 128" stroke="url(#atlas-gold-soft)" stroke-width="6" stroke-linecap="round" />
+  <path d="M160 20C150 36 144 54 144 74C144 94 150 112 160 128" stroke="url(#atlas-gold-soft)" stroke-width="6" stroke-linecap="round" />
+  <path d="M94 32C110 44 124 58 136 74C148 90 162 104 178 116" stroke="url(#atlas-gold-soft)" stroke-width="5" stroke-linecap="round" />
+  <path d="M178 32C162 44 148 58 136 74C124 90 110 104 94 116" stroke="url(#atlas-gold-soft)" stroke-width="5" stroke-linecap="round" />
+
+  <circle cx="126" cy="116" r="10" stroke="url(#atlas-gold)" stroke-width="6" />
+  <path d="M82 141C95 125 111 117 126 116" stroke="url(#atlas-gold)" stroke-width="8" stroke-linecap="round" />
+  <path d="M170 143C155 125 141 117 126 116" stroke="url(#atlas-gold)" stroke-width="8" stroke-linecap="round" />
+  <path d="M126 126L126 175" stroke="url(#atlas-gold)" stroke-width="8" stroke-linecap="round" />
+  <path d="M126 150L104 166" stroke="url(#atlas-gold-soft)" stroke-width="7" stroke-linecap="round" />
+  <path d="M126 150L146 168" stroke="url(#atlas-gold-soft)" stroke-width="7" stroke-linecap="round" />
+  <path d="M103 166L88 206" stroke="url(#atlas-gold)" stroke-width="8" stroke-linecap="round" />
+  <path d="M146 168L166 206" stroke="url(#atlas-gold)" stroke-width="8" stroke-linecap="round" />
+  <path d="M88 206H72M166 206H182" stroke="url(#atlas-gold-soft)" stroke-width="8" stroke-linecap="round" />
+  <path d="M66 214H192" stroke="url(#atlas-gold)" stroke-width="6" stroke-linecap="round" opacity="0.8" />
+</svg>

--- a/src/assets/pricing-icons/standard-plan-shield.svg
+++ b/src/assets/pricing-icons/standard-plan-shield.svg
@@ -1,0 +1,32 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="shield-gold" x1="32" y1="16" x2="224" y2="240" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F9E48A" />
+      <stop offset="0.5" stop-color="#EAB308" />
+      <stop offset="1" stop-color="#8B5E1A" />
+    </linearGradient>
+    <linearGradient id="shield-gold-soft" x1="48" y1="24" x2="208" y2="232" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE68A" />
+      <stop offset="0.55" stop-color="#FBBF24" />
+      <stop offset="1" stop-color="#B45309" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M128 20L214 54V118C214 177 176 224 128 238C80 224 42 177 42 118V54L128 20Z"
+    stroke="url(#shield-gold)"
+    stroke-width="12"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M128 46L188 70V118C188 161 162 194 128 207C94 194 68 161 68 118V70L128 46Z"
+    stroke="url(#shield-gold-soft)"
+    stroke-width="10"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M128 71L160 84V119C160 144 147 162 128 172C109 162 96 144 96 119V84L128 71Z"
+    stroke="url(#shield-gold-soft)"
+    stroke-width="9"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -9,14 +9,14 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import {
-  StandardIcon,
-  AdvancedIcon,
-  BuilderIcon,
   CheckIcon,
   ClockIcon,
   DollarIcon,
   ShieldIcon,
 } from "@/components/icons/PlanIcons";
+import standardPlanShieldIcon from "@/assets/pricing-icons/standard-plan-shield.svg";
+import advancedPlanSpartanHelmetIcon from "@/assets/pricing-icons/advanced-plan-spartan-helmet.svg";
+import builderPlanWorldHolderIcon from "@/assets/pricing-icons/builder-plan-world-holder.svg";
 import { useAuth } from "@/hooks/useAuth";
 import { checkoutApi } from "@/services/checkout";
 import ScrollReveal from "@/components/ui/ScrollReveal";
@@ -185,6 +185,44 @@ const positionSizingGuidance = [
   },
 ];
 
+type PricingPlanIconType = "standard" | "advanced" | "builder";
+
+const pricingPlanIconAssets: Record<
+  PricingPlanIconType,
+  { src: string; alt: string; fitClassName: string }
+> = {
+  standard: {
+    src: standardPlanShieldIcon,
+    alt: "Standard Plan Shield Icon",
+    fitClassName: "p-1",
+  },
+  advanced: {
+    src: advancedPlanSpartanHelmetIcon,
+    alt: "Advanced Plan Spartan Helmet Icon",
+    fitClassName: "p-0.5",
+  },
+  builder: {
+    src: builderPlanWorldHolderIcon,
+    alt: "Builder Plan World Holder Icon",
+    fitClassName: "p-0.5",
+  },
+};
+
+const PricingPlanIcon = ({ plan }: { plan: PricingPlanIconType }) => {
+  const { src, alt, fitClassName } = pricingPlanIconAssets[plan];
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={`w-full h-full object-contain object-center ${fitClassName}`}
+      loading="lazy"
+      decoding="async"
+      draggable={false}
+    />
+  );
+};
+
 const Pricing = () => {
   const location = useLocation();
   const navigate = useNavigate();
@@ -259,7 +297,7 @@ const Pricing = () => {
                   <div className="flex flex-col md:flex-row md:items-center gap-6">
                     <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-gold-dark to-primary p-0.5">
                       <div className="w-full h-full rounded-2xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                        <StandardIcon size={40} />
+                        <PricingPlanIcon plan="standard" />
                       </div>
                     </div>
                     <div>
@@ -426,7 +464,7 @@ const Pricing = () => {
                   <div className="flex flex-col md:flex-row md:items-center gap-6">
                     <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-primary to-gold-light p-0.5">
                       <div className="w-full h-full rounded-2xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                        <AdvancedIcon size={40} />
+                        <PricingPlanIcon plan="advanced" />
                       </div>
                     </div>
                     <div>
@@ -589,7 +627,7 @@ const Pricing = () => {
                   <div className="flex flex-col md:flex-row md:items-center gap-6">
                     <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-gold-dark via-primary to-gold-light p-0.5">
                       <div className="w-full h-full rounded-2xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                        <BuilderIcon size={40} />
+                        <PricingPlanIcon plan="builder" />
                       </div>
                     </div>
                     <div>
@@ -778,7 +816,7 @@ const Pricing = () => {
                           <div className="flex items-center gap-3">
                             <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-gold-dark to-primary p-0.5">
                               <div className="w-full h-full rounded-xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                                <StandardIcon size={20} />
+                                <PricingPlanIcon plan="standard" />
                               </div>
                             </div>
                             <div>
@@ -803,7 +841,7 @@ const Pricing = () => {
                           <div className="flex items-center gap-3">
                             <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-primary to-gold-light p-0.5">
                               <div className="w-full h-full rounded-xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                                <AdvancedIcon size={20} />
+                                <PricingPlanIcon plan="advanced" />
                               </div>
                             </div>
                             <div>
@@ -828,7 +866,7 @@ const Pricing = () => {
                           <div className="flex items-center gap-3">
                             <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-gold-dark via-primary to-gold-light p-0.5">
                               <div className="w-full h-full rounded-xl bg-card/90 backdrop-blur-sm flex items-center justify-center">
-                                <BuilderIcon size={20} />
+                                <PricingPlanIcon plan="builder" />
                               </div>
                             </div>
                             <div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replaced pricing page plan icons with new image assets:
  - Standard: shield
  - Advanced: spartan helmet
  - Builder: world holder
- added transparent SVG assets under `src/assets/pricing-icons/`
- introduced a small pricing-only icon image wrapper for consistent fit (`object-contain`, centered, normalized padding)
- preserved existing pricing layout, spacing, typography, and dark card/background styles
- applied exact alt text:
  - `Standard Plan Shield Icon`
  - `Advanced Plan Spartan Helmet Icon`
  - `Builder Plan World Holder Icon`
- removed pricing-page references to the old plan icon components (lightning/rocket/crown equivalents in pricing)

## Validation
- standard plan shows shield icon
- advanced plan shows spartan helmet icon
- builder plan shows world holder icon
- all icon links resolve from local assets (no broken references)
- responsive structure remains unchanged (desktop/mobile)

## Notes
- changes are scoped to the pricing page implementation only; unrelated components were not refactored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7762f565-1362-4869-b0c9-9d7f32629b7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7762f565-1362-4869-b0c9-9d7f32629b7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

