### PR TITLE
Update pre-launch announcement to Q2 2026

### DIFF
--- a/src/components/PreLaunchModal.tsx
+++ b/src/components/PreLaunchModal.tsx
@@ -59,7 +59,7 @@ const PreLaunchModal = ({
         </DialogHeader>
 
         <div className="space-y-4 text-sm md:text-base text-muted-foreground">
-          <p>Dynasty Futures is currently preparing for launch in Q1 2026.</p>
+          <p>Dynasty Futures is currently preparing for launch in Q2 2026.</p>
           <p>
             We are focused on building a stable, transparent, and trader-first
             proprietary futures firm. During this pre-launch period, certain


### PR DESCRIPTION
## Summary
- Updates the pre-launch modal announcement from Q1 2026 to Q2 2026

## Test plan
- [ ] Verify the PreLaunchModal displays "Q2 2026" when opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)