### PR TITLE
Update pre-launch announcement from Q1 to Q2 2026

### DIFF
--- a/src/components/PreLaunchModal.tsx
+++ b/src/components/PreLaunchModal.tsx
@@ -59,7 +59,7 @@ const PreLaunchModal = ({
         </DialogHeader>
 
         <div className="space-y-4 text-sm md:text-base text-muted-foreground">
-          <p>Dynasty Futures is currently preparing for launch in Q1 2026.</p>
+          <p>Dynasty Futures is currently preparing for launch in Q2 2026.</p>
           <p>
             We are focused on building a stable, transparent, and trader-first
             proprietary futures firm. During this pre-launch period, certain


### PR DESCRIPTION
## Summary
- Updated pre-launch modal announcement text from "Q1 2026" to "Q2 2026" in `src/components/PreLaunchModal.tsx`

## Test plan
- [ ] Open the app and verify the pre-launch modal shows "Q2 2026"
- [ ] Clear `localStorage` (`prelaunch-seen` key) if the modal has been dismissed previously to trigger it again

https://claude.ai/code/session_01EwGHEhSFDpYuCWCFmvtEpr