### PR TITLE
Update footer disclaimer, pricing card rules, and About page leadership

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -143,10 +143,15 @@ const Footer = () => {
             <p className="text-xs text-muted-foreground text-center md:text-left">
               © {new Date().getFullYear()} Dynasty Futures LLC. All rights reserved.
             </p>
-            <span className="text-xs text-muted-foreground">
-              All trading on Dynasty Futures is simulated. Payouts are based on
-              simulated trading performance. This is not real trading, and no
-              real capital is ever at risk.
+            <span className="text-xs text-muted-foreground max-w-2xl text-center md:text-right">
+              Dynasty Futures LLC offers simulated trading evaluation programs.
+              All trading activity, account metrics, performance results, and
+              payout determinations are based on simulated trading performance
+              within a simulated environment. Participants do not deposit or
+              risk personal trading capital in a live brokerage account. Any
+              payouts issued by Dynasty Futures are derived from the terms of
+              the applicable simulated program and are not returns on personal
+              investment activity.
             </span>
           </div>
         </div>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -384,6 +384,15 @@ const About = () => {
                     <p className="text-primary text-sm font-medium">
                       Chief Financial Officer
                     </p>
+                    <div className="flex items-center gap-3 mt-2">
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                        <MapPin className="w-3 h-3" />
+                        <span>Texas</span>
+                      </div>
+                      <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full border border-primary/20">
+                        Co-Founder
+                      </span>
+                    </div>
                   </div>
                   <div className="space-y-4 text-muted-foreground leading-relaxed">
                     <p>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -395,13 +395,8 @@ const Pricing = () => {
                       </tbody>
                     </table>
                   </div>
+                  {/* Universal rules — same across all plans */}
                   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <CheckIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        50% consistency rule (evaluation only)
-                      </span>
-                    </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <ClockIcon size={20} />
                       <span className="text-sm text-foreground">
@@ -415,6 +410,20 @@ const Pricing = () => {
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ShieldIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        Evaluations use a trailing end-of-day drawdown. Funded
+                        accounts use a static drawdown.
+                      </span>
+                    </div>
+                    {/* Plan-specific rules */}
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <CheckIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        50% consistency rule (evaluation only)
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <DollarIcon size={20} />
                       <span className="text-sm text-foreground">
                         Low activation fee
@@ -424,13 +433,6 @@ const Pricing = () => {
                       <CheckIcon size={20} />
                       <span className="text-sm text-foreground">
                         Overnight trading allowed
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <ShieldIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        Evaluations use a trailing end-of-day drawdown. Funded
-                        accounts use a static drawdown.
                       </span>
                     </div>
                   </div>
@@ -555,29 +557,12 @@ const Pricing = () => {
                       </tbody>
                     </table>
                   </div>
+                  {/* Universal rules — same across all plans */}
                   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <CheckIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        No consistency rule
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <CheckIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        Immediate activation
-                      </span>
-                    </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <ClockIcon size={20} />
                       <span className="text-sm text-foreground">
                         5-day payout cycles
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <CheckIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        Priority support
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
@@ -591,6 +576,25 @@ const Pricing = () => {
                       <span className="text-sm text-foreground">
                         Evaluations use a trailing end-of-day drawdown. Funded
                         accounts use a static drawdown.
+                      </span>
+                    </div>
+                    {/* Plan-specific rules */}
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <CheckIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        No consistency rule
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <CheckIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        Immediate activation
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <CheckIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        Priority support
                       </span>
                     </div>
                   </div>
@@ -719,26 +723,28 @@ const Pricing = () => {
                       </tbody>
                     </table>
                   </div>
+                  {/* Universal rules — same across all plans */}
                   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-primary/15 backdrop-blur-sm border border-primary/25">
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ClockIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        5-day payout cycles
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <CheckIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        Copy trading allowed
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ShieldIcon size={20} />
                       <span className="text-sm text-foreground">
                         Evaluations use a trailing end-of-day drawdown. Funded
                         accounts use a static drawdown.
                       </span>
                     </div>
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-primary/15 backdrop-blur-sm border border-primary/25">
-                      <ShieldIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        Higher max loss limit
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <DollarIcon size={20} />
-                      <span className="text-sm text-foreground">
-                        No activation fee
-                      </span>
-                    </div>
+                    {/* Plan-specific rules */}
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <CheckIcon size={20} />
                       <span className="text-sm text-foreground">
@@ -746,15 +752,15 @@ const Pricing = () => {
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <ClockIcon size={20} />
+                      <ShieldIcon size={20} />
                       <span className="text-sm text-foreground">
-                        2 minimum trading days to pass
+                        Largest MLL limits in the industry
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <CheckIcon size={20} />
+                      <DollarIcon size={20} />
                       <span className="text-sm text-foreground">
-                        Built for serious traders
+                        No activation fee
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary

- **Footer disclaimer**: Replaced short simulated-trading blurb with the full compliant disclaimer text covering evaluation programs, simulated environment, no personal capital at risk, and payout derivation language.
- **Pricing card rule consistency**: Reorganized the 6-rule grid under each plan so universal rules always appear first (positions 1–3) and plan-specific rules follow (positions 4–6). Normalized Builder card tile styling to match Standard/Advanced (removed highlighted `bg-primary/15` tiles).
- **Builder rule text change**: Changed "2 minimum trading days to pass" → "Largest MLL limits in the industry".
- **About page — Cliff Adams**: Added missing `Co-Founder` badge and `Texas` location to his leadership card, matching the identical metadata row pattern used for Brock and Zachary.

### Pricing — Universal rules (same position across all 3 cards)
1. 5-day payout cycles
2. Copy trading allowed
3. Evaluations use a trailing end-of-day drawdown. Funded accounts use a static drawdown.

### Pricing — Plan-specific rules (positions 4–6, unique per card)
| Standard | Advanced | Builder |
|---|---|---|
| 50% consistency rule | No consistency rule | 50% consistency rule |
| Low activation fee | Immediate activation | Largest MLL limits in the industry |
| Overnight trading allowed | Priority support | No activation fee |

### About page — Cliff Adams card (after)
- Chief Financial Officer
- Texas (MapPin icon)
- Co-Founder badge

## Test plan
- [ ] Visit `/pricing` — confirm all 3 cards show universal rules in the same first-row positions
- [ ] Confirm Builder card tiles all use the same muted background (no highlighted tiles)
- [ ] Confirm Builder shows "Largest MLL limits in the industry" (not "2 minimum trading days")
- [ ] Visit any page with the footer — confirm new multi-sentence disclaimer appears in the bottom bar
- [ ] Check desktop and mobile layouts for the footer disclaimer — text should wrap cleanly
- [ ] Visit `/about` — confirm Cliff Adams' card shows Texas location (MapPin) and Co-Founder badge, visually matching Brock and Zachary's cards

https://claude.ai/code/session_01U6kNecayxiq15tduDsngLr