### PR TITLE
Correct MLL and profit target values for 100K and 150K accounts

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -89,7 +89,7 @@ const faqs = [
     id: "profit-target",
     question: "What is the profit target?",
     answer:
-      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $8,000. Once you reach your profit target while following all rules, you pass the challenge.",
+      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $9,000. Once you reach your profit target while following all rules, you pass the challenge.",
   },
   {
     id: "five-payouts",

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -134,12 +134,12 @@ const standardAdvancedRules = {
   },
   "$100,000": {
     profitTarget: "$6,000",
-    maxDrawdown: "$2,500",
+    maxDrawdown: "$3,000",
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$8,000",
-    maxDrawdown: "$4,000",
+    profitTarget: "$9,000",
+    maxDrawdown: "$4,500",
     dailyLoss: "$3,000",
   },
 };
@@ -157,12 +157,12 @@ const builderRules = {
   },
   "$100,000": {
     profitTarget: "$6,000",
-    maxDrawdown: "$3,000",
+    maxDrawdown: "$3,500",
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$8,000",
-    maxDrawdown: "$4,500",
+    profitTarget: "$9,000",
+    maxDrawdown: "$5,000",
     dailyLoss: "$3,000",
   },
 };

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -165,15 +165,15 @@ const accountRules = [
   {
     size: "100K Account",
     profitTarget: "$6,000",
-    standardAdvancedMaxDrawdown: "$2,500",
-    builderMaxDrawdown: "$3,000",
+    standardAdvancedMaxDrawdown: "$3,000",
+    builderMaxDrawdown: "$3,500",
     dailyLoss: "$2,000",
   },
   {
     size: "150K Account",
-    profitTarget: "$8,000",
-    standardAdvancedMaxDrawdown: "$4,000",
-    builderMaxDrawdown: "$4,500",
+    profitTarget: "$9,000",
+    standardAdvancedMaxDrawdown: "$4,500",
+    builderMaxDrawdown: "$5,000",
     dailyLoss: "$3,000",
   },
 ];
@@ -666,9 +666,9 @@ const Rules = () => {
                     drawdown remains constant.
                   </p>
                   <p className="text-muted-foreground mb-4">
-                    For example, if you have a $100,000 account with a $2,500
+                    For example, if you have a $100,000 account with a $3,000
                     static drawdown, your account will be violated if your
-                    balance drops below $97,500 at any point. This level does
+                    balance drops below $97,000 at any point. This level does
                     not change regardless of how much profit you make.
                   </p>
                   <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary

Corrects stale Max Loss Limit and Profit Target values for the 100K and 150K account sizes across all three plans. Updates applied at every source-of-truth location — no hardcoded isolated patches.

## Value changes

| Plan | Account | Field | Old | New |
|---|---|---|---|---|
| Standard & Advanced | 100K | Max Loss Limit | $2,500 | $3,000 |
| Standard & Advanced | 150K | Max Loss Limit | $4,000 | $4,500 |
| Standard & Advanced | 150K | Profit Target | $8,000 | $9,000 |
| Builder | 100K | Max Loss Limit | $3,000 | $3,500 |
| Builder | 150K | Max Loss Limit | $4,500 | $5,000 |
| Builder | 150K | Profit Target | $8,000 | $9,000 |

## Files changed

- **`src/pages/Pricing.tsx`** — `standardAdvancedRules` and `builderRules` data objects (drives all three pricing card tables)
- **`src/pages/Rules.tsx`** — `accountRules` data object (drives the Rules page table) + inline static-drawdown example updated from `$2,500 / $97,500` → `$3,000 / $97,000`
- **`src/pages/FAQ.tsx`** — profit target FAQ answer updated from `$8,000` → `$9,000` for 150K accounts

## Test plan
- [ ] `/pricing` — Standard 100K row: MLL = $3,000 ✓
- [ ] `/pricing` — Standard 150K row: MLL = $4,500, Profit Target = $9,000 ✓
- [ ] `/pricing` — Advanced 100K row: MLL = $3,000 ✓
- [ ] `/pricing` — Advanced 150K row: MLL = $4,500, Profit Target = $9,000 ✓
- [ ] `/pricing` — Builder 100K row: MLL = $3,500 ✓
- [ ] `/pricing` — Builder 150K row: MLL = $5,000, Profit Target = $9,000 ✓
- [ ] `/rules` — account rules table matches updated values for all plans ✓
- [ ] `/rules` — static drawdown example reads "$3,000" / "below $97,000" ✓
- [ ] `/faq` — profit target answer reads "$9,000" for 150K accounts ✓
- [ ] No visual/layout regressions on desktop or mobile ✓

https://claude.ai/code/session_01U6kNecayxiq15tduDsngLr