### PR TITLE
Content accuracy and polish cleanup pass

### DIFF
--- a/src/components/home/SimulatedTrading.tsx
+++ b/src/components/home/SimulatedTrading.tsx
@@ -36,9 +36,8 @@ const SimulatedTrading = () => {
             </h2>
             <p className="text-lg text-muted-foreground mb-8">
               All trading at Dynasty Futures occurs on simulated accounts using
-              real-time or near real-time futures market data. This environment
-              mirrors live market conditions but does not involve live capital
-              at any stage.
+              real-time futures market data. This environment mirrors live
+              market conditions but does not involve live capital at any stage.
             </p>
 
             <div className="space-y-6">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -144,14 +144,12 @@ const Footer = () => {
               © {new Date().getFullYear()} Dynasty Futures LLC. All rights reserved.
             </p>
             <span className="text-xs text-muted-foreground max-w-2xl text-center md:text-right">
-              Dynasty Futures LLC offers simulated trading evaluation programs.
-              All trading activity, account metrics, performance results, and
-              payout determinations are based on simulated trading performance
-              within a simulated environment. Participants do not deposit or
-              risk personal trading capital in a live brokerage account. Any
-              payouts issued by Dynasty Futures are derived from the terms of
-              the applicable simulated program and are not returns on personal
-              investment activity.
+              All trading activity through Dynasty Futures LLC takes place in a
+              simulated environment. Evaluations, account performance, and
+              payout eligibility are based on simulated trading results.
+              Participants do not risk personal trading capital, and payouts, if
+              any, are made in accordance with the rules and terms of the
+              applicable program.
             </span>
           </div>
         </div>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -130,8 +130,8 @@ const About = () => {
                 </p>
                 <p>
                   When Brock started looking seriously at the futures trading
-                  world — during his time studying finance at the University of
-                  Utah — he quickly became drawn to the markets: the structure,
+                  world, during his time studying finance at the University of
+                  Utah, he quickly became drawn to the markets: the structure,
                   the discipline, the opportunity. But the deeper he got into
                   the prop firm side of things, a pattern kept showing up:
                   confusing rules, gimmicky pricing, and payout structures
@@ -139,13 +139,13 @@ const About = () => {
                 </p>
                 <p>
                   Dynasty Futures LLC was incorporated in Wyoming with one
-                  clear goal — build the firm the space was missing. Fair
+                  clear goal: build the firm the space was missing. Fair
                   pricing, higher max loss limits, and a payout philosophy that
                   doesn't leave people guessing.
                 </p>
                 <p>
                   The bigger vision was to build something traders could grow
-                  with — a firm that scales as its traders scale. As that vision
+                  with, a firm that scales as its traders scale. As that vision
                   became real, the right people, systems, and partnerships came
                   together. What started as a simple frustration became a
                   company.
@@ -243,7 +243,7 @@ const About = () => {
                   what they signed up for.
                 </p>
                 <p>
-                  At Dynasty, we've tried to make everything clear — the rules,
+                  At Dynasty, we've tried to make everything clear: the rules,
                   the pricing, the payout structure, the expectations. We'd
                   rather tell you something upfront you don't want to hear than
                   leave you confused after the fact.
@@ -277,7 +277,7 @@ const About = () => {
               </h2>
               <p className="text-center text-muted-foreground mb-12 max-w-xl mx-auto">
                 Dynasty Futures is led by people with real backgrounds in
-                finance, strategy, and business — not a faceless operation.
+                finance, strategy, and business, not a faceless operation.
               </p>
             </ScrollReveal>
 
@@ -307,14 +307,14 @@ const About = () => {
                   <p>
                     Born and raised in Texas, Brock studied and graduated in
                     finance from the University of Utah, where he developed a
-                    genuine interest in the financial markets — particularly
+                    genuine interest in the financial markets, particularly
                     futures trading. He spent years learning how markets move,
                     what consistent trading actually looks like, and what it
                     takes to perform at a high level over time.
                   </p>
                   <p>
                     Before founding Dynasty Futures, Brock built experience in
-                    private equity, capital raising, and leadership — giving him
+                    private equity, capital raising, and leadership, giving him
                     a clear picture of what a well-run firm looks like and what
                     most firms in this space were missing.
                   </p>
@@ -367,7 +367,7 @@ const About = () => {
                     </p>
                     <p>
                       At Dynasty, Zachary brings a thoughtful, strategic
-                      perspective to every part of the business — from how the
+                      perspective to every part of the business, from how the
                       company positions itself to how it grows. His approach
                       helps keep the firm focused on what matters long term.
                     </p>
@@ -423,7 +423,7 @@ const About = () => {
               </h2>
               <p className="text-muted-foreground mb-8 text-lg">
                 Dynasty Futures is for traders who value structure, opportunity,
-                professionalism, and transparency — not flashy promotions and
+                professionalism, and transparency, not flashy promotions and
                 vague claims. If that's you, you're in the right place.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -23,7 +23,7 @@ const faqs = [
     id: "simulated-trading",
     question: "How does simulated trading work?",
     answer:
-      "During the challenge phase, you trade in a simulated environment that mirrors real futures markets. Price data is real-time or near real-time, and orders are routed through supported platforms like Volumetrica with DeepCharts data feed integration. You never trade live capital—simulated trading is used in both the evaluation and funded phases.",
+      "During the challenge phase, you trade in a simulated environment that mirrors real futures markets. Price data is real-time, and orders are routed through supported platforms like Volumetrica with DeepCharts data feed integration. You never trade live capital; simulated trading is used in both the evaluation and funded phases.",
   },
   {
     id: "payouts",

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -70,10 +70,13 @@ const Legal = () => {
                   <div className="prose prose-invert max-w-none space-y-4 text-muted-foreground">
                     <p>
                       <strong className="text-foreground">IMPORTANT:</strong>{" "}
-                      All trading on Dynasty Futures is simulated. Payouts are
-                      based on simulated trading performance. This is not real
-                      trading, and no real capital is ever at risk. Past
-                      simulated performance does not guarantee future results.
+                      All trading activity through Dynasty Futures LLC takes
+                      place in a simulated environment. Evaluations, account
+                      performance, and payout eligibility are based on
+                      simulated trading results. Participants do not risk
+                      personal trading capital, and payouts, if any, are made
+                      in accordance with the rules and terms of the applicable
+                      program.
                     </p>
 
                     <h3 className="text-foreground font-display text-lg mt-6">
@@ -82,9 +85,9 @@ const Legal = () => {
                     <p>
                       All trading at Dynasty Futures takes place in a simulated
                       environment. No live capital is ever traded. You trade
-                      using real-time or near real-time market data, but all
-                      orders and executions are simulated. Payouts are based
-                      entirely on your simulated trading performance.
+                      using real-time market data, but all orders and
+                      executions are simulated. Payouts are based entirely on
+                      your simulated trading performance.
                     </p>
 
                     <h3 className="text-foreground font-display text-lg mt-6">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -754,7 +754,7 @@ const Pricing = () => {
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <ShieldIcon size={20} />
                       <span className="text-sm text-foreground">
-                        Largest MLL limits in the industry
+                        Largest max loss limits in the industry
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -213,7 +213,6 @@ const planRules = [
     features: [
       "Higher max loss limit than Standard",
       "50% consistency rule (evaluation phase)",
-      "2 minimum trading days to pass",
       "No activation fee",
       "5-day payout cycles",
       "Static drawdown",
@@ -712,15 +711,6 @@ const Rules = () => {
                         <td className="py-4 px-6 text-muted-foreground">
                           50% consistency rule applies during the evaluation
                           phase.
-                        </td>
-                      </tr>
-                      <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Minimum Trading Days
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          2 minimum trading days are required to pass
-                          evaluation.
                         </td>
                       </tr>
                       <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">


### PR DESCRIPTION
## Summary

- **Pricing card:** "Largest MLL limits in the industry" → "Largest max loss limits in the industry"
- **Builder Plan rules:** Removed inaccurate "2 minimum trading days to pass" from both the features list and the rules summary table
- **Disclaimer consistency:** Aligned footer disclaimer and Risk Disclosure "IMPORTANT" notice to the canonical simulated-trading language; also removed "or near real-time" from the Legal page body and the home SimulatedTrading component so the language is consistent site-wide
- **FAQ:** Updated the "How does simulated trading work?" answer to the exact approved wording (removes "or near real-time", changes em dash to semicolon before "simulated trading is used…")
- **About page:** Softened unnecessary em dash interruptions (replaced with commas or colons where the sentence reads more naturally); no content, facts, or structure changed

## Files changed

| File | Change |
|---|---|
| `src/pages/Pricing.tsx` | MLL → max loss limits |
| `src/pages/Rules.tsx` | Remove minimum trading days feature + table row |
| `src/components/layout/Footer.tsx` | Canonical disclaimer language |
| `src/pages/Legal.tsx` | Match IMPORTANT notice to footer; remove "near real-time" from body |
| `src/components/home/SimulatedTrading.tsx` | Remove "or near real-time" |
| `src/pages/FAQ.tsx` | Exact updated simulated trading answer |
| `src/pages/About.tsx` | Em dash softening only — no content changes |

## Test plan

- [ ] Pricing page: Builder plan card shows "Largest max loss limits in the industry"
- [ ] Rules page: Builder Plan summary has no "minimum trading days" entry; table row is gone
- [ ] Footer disclaimer matches the Legal > Risk Disclosure IMPORTANT notice exactly
- [ ] FAQ accordion: "How does simulated trading work?" shows the updated answer with no "near real-time"
- [ ] About page: all sections, bios, and facts intact; no em dash interruptions in updated passages
- [ ] No layout regressions on desktop or mobile

https://claude.ai/code/session_01TUNAu9naMj2tBDHLq4Bwia