### PR TITLE
Update post-5-payout policy copy on Rules and Pricing pages

### DIFF
--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -970,6 +970,21 @@ const Pricing = () => {
                 automatically.
               </p>
             </section>
+
+            <ScrollReveal as="section" className="mb-12">
+              <div className="glass-card rounded-2xl border border-border/50 p-6 md:p-8 text-center">
+                <h2 className="font-display text-xl font-semibold text-foreground mb-3">
+                  Long Term Payout Structure
+                </h2>
+                <p className="text-muted-foreground max-w-2xl mx-auto text-sm">
+                  After five approved payouts, traders move into an 80/20 profit
+                  split with eighty percent going to the trader. There is no
+                  forced transition to a live account at that stage. Many traders
+                  prefer staying in the environment they already know, and we
+                  built this structure to support that choice.
+                </p>
+              </div>
+            </ScrollReveal>
           </div>
         </div>
       </div>

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -140,9 +140,9 @@ const universalRules = [
   },
   {
     icon: DollarIcon,
-    title: "Post-5 Payout Profit Split Adjustment",
+    title: "Long Term Payout Structure: 80/20 Split After Five Payouts",
     description:
-      "After a trader has successfully completed five (5) payouts, all future payouts will be subject to an 80/20 profit split, with 80% paid to the trader and 20% retained by Dynasty Futures.",
+      "Once a trader reaches five approved payouts, the account moves into our long term payout structure with an 80/20 profit split. Eighty percent of all future profits goes to the trader. This is a milestone that reflects consistency and performance, and we designed the structure around it. Traders are not required to transition to a live account at that stage. Many prefer staying in the environment they already know and trust, and we want to preserve that continuity while supporting long term growth.",
     allowed: true,
   },
 ];


### PR DESCRIPTION
## Summary

- Rewrites the Rules page entry for the long term payout structure to be trader-first and benefit-forward, framing the 80/20 profit split milestone as a reward for consistency and performance
- Makes clear that traders are not required to transition to a live account after five approved payouts, and that Dynasty Futures preserves continuity for traders who prefer staying in the environment they know
- Adds a brief, scannable callout section at the bottom of the Pricing page reinforcing the same milestone in clean, on-brand copy

## Changes

**Rules page (`src/pages/Rules.tsx`)**
- Renamed the rule from "Post-5 Payout Profit Split Adjustment" to "Long Term Payout Structure: 80/20 Split After Five Payouts"
- Rewrote the description to be trader-first: confirms 80% goes to the trader, no forced live account transition, continuity preserved for traders who prefer staying in the simulated environment

**Pricing page (`src/pages/Pricing.tsx`)**
- Added a new "Long Term Payout Structure" section near the bottom of the page with brief, easy-to-scan copy covering the 80/20 split after five approved payouts and the no-forced-live-transition policy

## Test plan

- [ ] Visit `/rules` and open the Universal Rules accordion, confirm the updated rule title and description appear correctly under "Allowed & Approved"
- [ ] Visit `/pricing` and scroll to the bottom, confirm the new "Long Term Payout Structure" section appears cleanly after the Position Sizing section
- [ ] Confirm no dashes appear in any of the new copy
- [ ] Confirm tone reads as a trader benefit, not a restriction

https://claude.ai/code/session_01AiJHGrFxoQQN18rEtDWREt