### PR TITLE
Targeted content and UI updates: marquee speed, icons, copy, disclaimer

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -154,6 +154,42 @@ const Footer = () => {
             </span>
           </div>
         </div>
+
+        {/* Regulatory Disclaimer */}
+        <div className="mt-6 pt-6 border-t border-border/20">
+          <p className="text-xs text-muted-foreground/70 leading-relaxed mb-3">
+            Any references on this website to trading, traders, accounts,
+            performance, revenue, profits, or payouts refer to simulated or
+            evaluation-based activity unless expressly stated otherwise.
+            Dynasty Futures provides proprietary trading evaluation services
+            and does not offer investment advice, brokerage services, or live
+            client investment accounts. Futures trading involves substantial
+            risk and is not appropriate for every person. Past performance,
+            whether actual, simulated, or advertised, is not indicative of
+            future results.
+          </p>
+          <p className="text-xs text-muted-foreground/70 leading-relaxed mb-3">
+            Any performance information, metrics, or examples shown on this
+            website may be based on simulated, hypothetical, or evaluation
+            account performance. Hypothetical results do not reflect real
+            market execution, liquidity constraints, or slippage, and may
+            overstate or understate actual performance. No representation is
+            made that any user will achieve profits or losses similar to those
+            referenced. Payout examples and testimonials are not a guarantee
+            of future success. Individual results vary.
+          </p>
+          <p className="text-xs text-muted-foreground/70 leading-relaxed">
+            <strong className="text-muted-foreground/90">CFTC Rule 4.41:</strong>{" "}
+            Hypothetical or simulated performance results have certain inherent
+            limitations. Unlike an actual performance record, simulated results
+            do not represent actual trading. Because trades have not been
+            executed, results may have under- or over-compensated for the
+            impact of certain market factors, including lack of liquidity.
+            Simulated trading programs are also designed with the benefit of
+            hindsight. No representation is made that any account will or is
+            likely to achieve profits or losses similar to those shown.
+          </p>
+        </div>
       </div>
 
       <PreLaunchModal

--- a/src/components/ui/SponsorTicker.tsx
+++ b/src/components/ui/SponsorTicker.tsx
@@ -38,6 +38,12 @@ const SponsorTicker = ({
               -webkit-animation: scroll-sponsors 30s linear infinite;
               animation: scroll-sponsors 30s linear infinite;
             }
+            @media (max-width: 768px) {
+              .sponsor-track {
+                -webkit-animation-duration: 14s;
+                animation-duration: 14s;
+              }
+            }
             .sponsor-image-wrapper {
               display: flex;
               flex-shrink: 0;

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -263,7 +263,7 @@ const About = () => {
               </div>
               <div className="mt-6 pt-6 border-t border-border/30 flex items-center gap-2 text-xs text-muted-foreground">
                 <Building2 className="w-3.5 h-3.5 flex-shrink-0" />
-                <span>Dynasty Futures LLC — Registered in Wyoming</span>
+                <span>Dynasty Futures LLC, registered in Wyoming</span>
               </div>
             </div>
           </ScrollReveal>

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -77,7 +77,7 @@ const faqs = [
     id: "consistency",
     question: "Is there a consistency rule?",
     answer:
-      "Yes — on Standard and Builder during evaluation.\n\nBoth Standard and Builder include a 50% consistency rule during the evaluation phase, meaning no single trading day may account for more than 50% of the total profit target.\n\nOnce the evaluation is passed and the account is approved for funding, the consistency rule is removed.\n\nAdvanced does not include a consistency rule, and no funded accounts are subject to a consistency rule.",
+      "Yes, on Standard and Builder during evaluation.\n\nBoth Standard and Builder include a 50% consistency rule during the evaluation phase, meaning no single trading day may account for more than 50% of the total profit target.\n\nOnce the evaluation is passed and the account is approved for funding, the consistency rule is removed.\n\nAdvanced does not include a consistency rule, and no funded accounts are subject to a consistency rule.",
   },
   {
     id: "getting-started",

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -227,6 +227,77 @@ const Legal = () => {
                       resulting from your use of our services or any related
                       matter.
                     </p>
+
+                    <h3 className="text-foreground font-display text-lg mt-6">
+                      Simulated Trading Disclosure
+                    </h3>
+                    <p>
+                      Any references on this website to trading, traders,
+                      accounts, performance, revenue, profits, or payouts refer
+                      to simulated or evaluation-based activity unless expressly
+                      stated otherwise. Dynasty Futures provides proprietary
+                      trading evaluation services and does not offer investment
+                      advice, brokerage services, or live client investment
+                      accounts.
+                    </p>
+
+                    <p>
+                      Futures trading involves substantial risk and is not
+                      appropriate for every person. Market conditions can change
+                      rapidly, and trading futures or futures-related products
+                      can result in significant losses. Only risk capital should
+                      ever be used in connection with trading activity. Past
+                      performance, whether actual, simulated, or advertised, is
+                      not indicative of future results.
+                    </p>
+
+                    <p>
+                      Any performance information, metrics, results, or examples
+                      shown on this website, in dashboards, on social media, in
+                      promotional content, or in other materials may be based on
+                      simulated, hypothetical, or evaluation account performance.
+                      Hypothetical or simulated results have important
+                      limitations. Unlike actual trading, simulated results do
+                      not reflect real market execution, liquidity constraints,
+                      slippage, emotional decision-making, or the impact of live
+                      market conditions. Because hypothetical results are often
+                      prepared with the benefit of hindsight, they may overstate
+                      or understate actual performance.
+                    </p>
+
+                    <p>
+                      No representation is being made that any user, trader, or
+                      account will achieve profits or losses similar to those
+                      referenced on this website or in any Dynasty Futures
+                      material. There is no guarantee that any participant will
+                      pass an evaluation, receive a funded account, earn profits,
+                      or receive payouts.
+                    </p>
+
+                    <p>
+                      Payout examples, testimonials, and user experiences shown
+                      on this website may not be representative of the experience
+                      of all users. Testimonials are not a guarantee of future
+                      success or performance. Individual results vary based on
+                      many factors, including skill, market conditions, risk
+                      management, and adherence to program rules.
+                    </p>
+
+                    <h3 className="text-foreground font-display text-lg mt-6">
+                      CFTC Rule 4.41 Disclosure
+                    </h3>
+                    <p>
+                      Hypothetical or simulated performance results have certain
+                      inherent limitations. Unlike an actual performance record,
+                      simulated results do not represent actual trading. Also,
+                      because the trades have not been executed, the results may
+                      have under- or over-compensated for the impact, if any, of
+                      certain market factors, including lack of liquidity.
+                      Simulated trading programs in general are also designed
+                      with the benefit of hindsight. No representation is being
+                      made that any account will or is likely to achieve profits
+                      or losses similar to those shown.
+                    </p>
                   </div>
                 </div>
               </TabsContent>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -410,7 +410,7 @@ const Pricing = () => {
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <ShieldIcon size={20} />
+                      <ShieldIcon size={28} />
                       <span className="text-sm text-foreground">
                         Evaluations use a trailing end-of-day drawdown. Funded
                         accounts use a static drawdown.
@@ -572,7 +572,7 @@ const Pricing = () => {
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <ShieldIcon size={20} />
+                      <ShieldIcon size={28} />
                       <span className="text-sm text-foreground">
                         Evaluations use a trailing end-of-day drawdown. Funded
                         accounts use a static drawdown.
@@ -738,7 +738,7 @@ const Pricing = () => {
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
-                      <ShieldIcon size={20} />
+                      <ShieldIcon size={28} />
                       <span className="text-sm text-foreground">
                         Evaluations use a trailing end-of-day drawdown. Funded
                         accounts use a static drawdown.

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -504,7 +504,7 @@ const Rules = () => {
                 <span className="text-gradient-animated">Definitions</span>
               </h1>
               <p className="text-lg text-muted-foreground">
-                Dynasty Futures — Official Trading Rules. Applies to ALL plans
+                Official Trading Rules for Dynasty Futures. Applies to ALL plans
                 unless otherwise stated.
               </p>
             </div>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -180,6 +180,7 @@ const Support = () => {
                               Challenge Rules
                             </SelectItem>
                             <SelectItem value="payouts">Payouts</SelectItem>
+                            <SelectItem value="affiliate">Affiliate</SelectItem>
                             <SelectItem value="other">Other</SelectItem>
                           </SelectContent>
                         </Select>


### PR DESCRIPTION
## Summary

- **Mobile marquee speed** — Increased the infrastructure logo strip animation from 30s to 14s on screens ≤768px so it scrolls noticeably faster while remaining smooth on desktop
- **Pricing card ShieldIcon** — Enlarged the shield icon from size 20 → 28 on the "Evaluations use a trailing end-of-day drawdown" rule across all three plan cards (Standard, Advanced, Builder)
- **Support form** — Added "Affiliate" as a subject option in the dropdown, positioned between Payouts and Other
- **Terms of Use** — Appended the full simulated trading disclosure and CFTC Rule 4.41 disclosure block at the bottom of the Terms of Use tab in Legal.tsx
- **Footer disclaimer** — Added a three-paragraph regulatory disclaimer (simulated trading, hypothetical results, CFTC 4.41) below the existing bottom bar in a compact, readable format
- **AI-feeling dashes removed** — Softened three robotic dash separators in visible copy: `Yes —` → `Yes,` (FAQ), `Dynasty Futures — Official Trading Rules` → `Official Trading Rules for Dynasty Futures` (Rules), and `Dynasty Futures LLC — Registered in Wyoming` → `Dynasty Futures LLC, registered in Wyoming` (About)

## Test plan

- [ ] Visit `/` on mobile — confirm logo ticker scrolls faster than desktop
- [ ] Visit `/pricing` — verify shield icon is visibly larger on the drawdown rule row on all three plan cards
- [ ] Visit `/support` — open subject dropdown and confirm "Affiliate" appears between Payouts and Other
- [ ] Visit `/legal` → Terms of Use tab — scroll to bottom and confirm full simulated trading + CFTC 4.41 disclosure is present
- [ ] Scroll to footer on any page — confirm three-paragraph regulatory disclaimer appears below existing bottom bar
- [ ] Visit `/faq`, `/rules`, `/about` — confirm dashes are removed/softened in the affected lines

https://claude.ai/code/session_012Lt5Zu3hxnSRMazdCqA3Cn