### PR TITLE
feat: apply premium animated background globally across all pages

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -6,7 +6,6 @@ import logo from "@/assets/DF_Logo.png";
 
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { useScrollProgress } from "@/hooks/useScrollProgress";
-import BackgroundScene from "@/components/ui/aurora-section-hero";
 
 const Hero = () => {
   const sectionRef = useRef<HTMLElement>(null);
@@ -84,15 +83,6 @@ const Hero = () => {
       ref={sectionRef}
       className="relative min-h-[100vh] flex items-center overflow-hidden"
     >
-      {/* Deep charcoal base — the new site-wide foundation color */}
-      <div
-        className="absolute inset-0"
-        style={{
-          background:
-            "linear-gradient(180deg, #050505 0%, #0d0d0d 45%, #111111 100%)",
-        }}
-      />
-
       {/* Subtle tonal depth layer — crisp, no blur, adds structural interest */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -104,9 +94,6 @@ const Hero = () => {
           `,
         }}
       />
-
-      {/* Gold beam animation — hero-only, layered on top of charcoal base */}
-      <BackgroundScene beamCount={18} />
 
       {/* Readability overlay — subtle dark veil so hero text stays crisp */}
       <div

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import Navbar from "./Navbar";
 import Footer from "./Footer";
+import BackgroundScene from "@/components/ui/aurora-section-hero";
 
 interface LayoutProps {
   children: ReactNode;
@@ -9,10 +10,26 @@ interface LayoutProps {
 
 const Layout = ({ children, hideFooter = false }: LayoutProps) => {
   return (
-    <div className="min-h-screen bg-black flex flex-col relative">
+    <div className="min-h-screen flex flex-col relative">
+      {/* Global premium animated background — single fixed layer behind all pages */}
+      <div
+        className="fixed inset-0 pointer-events-none"
+        style={{
+          background:
+            "linear-gradient(180deg, #050505 0%, #0d0d0d 45%, #111111 100%)",
+          zIndex: 0,
+        }}
+        aria-hidden="true"
+      >
+        <BackgroundScene beamCount={18} />
+      </div>
       <Navbar />
       <main className="flex-1 pt-16 md:pt-20 relative z-[1]">{children}</main>
-      {!hideFooter && <Footer />}
+      {!hideFooter && (
+        <div className="relative z-[1]">
+          <Footer />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

- Moves the existing `BackgroundScene` (animated gold-stripe beams) from the home page `Hero` component into `Layout` as a single `position: fixed` layer — so every public page inherits the same continuous premium dark background without duplicating any animation logic
- Removes the now-redundant `BackgroundScene` usage and charcoal base gradient div from `Hero` (those are now provided globally)
- All animation keyframes and CSS classes (`rise`, `fade`, `floorGlow`, `mainGlow`, `.scene`, `.floor`, `.main-column`, `.light-beam`) were already globally scoped in `index.css` — no CSS changes were needed

## Changes

**`src/components/layout/Layout.tsx`**
- Import `BackgroundScene` from `aurora-section-hero`
- Render it inside a `position: fixed; inset: 0; z-index: 0; pointer-events: none` container with the charcoal base gradient — this becomes the single shared background for all pages
- Remove `bg-black` from the outer wrapper (background now comes from the fixed layer)
- Wrap `<Footer>` in `relative z-[1]` to keep it in the correct stacking layer above the fixed background

**`src/components/home/Hero.tsx`**
- Remove `BackgroundScene` import and its JSX usage (now global)
- Remove the "Deep charcoal base" absolute div (now global)
- Retain all hero-specific readability overlays, tonal depth layer, content, and bottom fade — nothing visual is lost

## What this achieves

- Single animated background instance — no performance duplication
- Background is `position: fixed` so it stays in place during scroll, feels continuous across section breaks and page transitions
- `pointer-events: none` ensures zero interference with buttons, inputs, dropdowns, modals, or nav
- Navbar (`z-50`) and main content (`z-[1]`) already had correct z-index — no changes needed there
- `pricing-bg` overlay, glass cards, and all other per-section readability layers continue to work unchanged on top of the global background

## Test plan

- [ ] Home page: hero, stats, pricing preview, footer all render correctly with animated beams visible
- [ ] Pricing page: content readable, `pricing-bg` overlay still provides depth, beams visible behind panels
- [ ] Rules, FAQ, Support, Affiliates, Legal pages: animated background visible, no overflow or clipping issues
- [ ] Login / Register pages: forms readable, background visible
- [ ] Scroll through a long page and verify the background stays fixed (no restart between sections)
- [ ] Navbar stays on top, footer renders correctly
- [ ] No horizontal scrollbar introduced
- [ ] `?noBlur=1` / `?noAtmosphere=1` performance flags still respected

https://claude.ai/code/session_014gZ3U6TfphiZDeAkEeyg7m