### PR TITLE
Integrate Rise Works as payout provider across dashboard and FAQ

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -26,10 +26,16 @@ const faqs = [
       "During the challenge phase, you trade in a simulated environment that mirrors real futures markets. Price data is real-time, and orders are routed through supported platforms like Volumetrica with DeepCharts data feed integration. You never trade live capital; simulated trading is used in both the evaluation and funded phases.",
   },
   {
+    id: "how-payouts-work",
+    question: "How do payouts work?",
+    answer:
+      "All payouts are processed through Rise Works, a trusted third-party payment provider. Rise manages payment processing, identity verification, and compliance to ensure payouts are handled securely and efficiently.\n\nOnce you are eligible for a payout, you will complete a verification process through Rise Works. This typically includes confirming your identity and payment details.\n\nPayouts are not denied without cause. As long as your information is accurate and verification is completed successfully, your payout will be processed. Issues only arise in cases of incomplete verification or fraudulent information.",
+  },
+  {
     id: "payouts",
     question: "When do payouts happen?",
     answer:
-      "For Standard, Advanced, and Builder plans, payouts occur on 5-day cycles once you're funded. Monthly caps remain structured by plan and account type.",
+      "For Standard, Advanced, and Builder plans, payouts occur on 5-day cycles once you're funded. Monthly caps remain structured by plan and account type. Payouts are processed through Rise Works after approval and may require standard verification before funds are released.",
   },
   {
     id: "static-drawdown",

--- a/src/pages/dashboard/DashboardPayouts.tsx
+++ b/src/pages/dashboard/DashboardPayouts.tsx
@@ -3,7 +3,6 @@ import {
   Clock,
   CheckCircle,
   XCircle,
-  Landmark,
   Globe,
   CircleDollarSign,
   ArrowUpRight,
@@ -36,21 +35,21 @@ const payoutHistory = [
     id: "1",
     date: "2025-01-28",
     amount: "$3,500",
-    method: "Wise Transfer",
+    method: "Rise Works",
     status: "Completed",
   },
   {
     id: "2",
     date: "2025-01-15",
     amount: "$2,200",
-    method: "Bank Transfer",
+    method: "Rise Works",
     status: "Completed",
   },
   {
     id: "3",
     date: "2025-02-05",
     amount: "$4,800",
-    method: "Wise Transfer",
+    method: "Rise Works",
     status: "Processing",
   },
 ];
@@ -83,10 +82,8 @@ const getStatusStyle = (status: string) => {
 
 const getMethodIcon = (method: string) => {
   switch (method) {
-    case "Wise Transfer":
+    case "Rise Works":
       return <Globe size={16} className="text-gold-dark" />;
-    case "Bank Transfer":
-      return <Landmark size={16} className="text-gold-light" />;
     default:
       return <CircleDollarSign size={16} className="text-muted-foreground" />;
   }
@@ -146,24 +143,15 @@ const DashboardPayouts = () => {
                 </p>
               </div>
             </div>
-            <div className="flex items-start gap-3">
+            <div className="flex items-start gap-3 col-span-2">
               <div className="w-8 h-8 rounded-lg bg-gold-light/10 flex items-center justify-center flex-shrink-0">
                 <Globe size={16} className="text-gold-light" />
               </div>
               <div>
-                <p className="text-xs text-muted-foreground">Wise Transfer</p>
+                <p className="text-xs text-muted-foreground">Payment Method</p>
                 <p className="text-sm font-medium text-foreground">
-                  Same day - 2 days
+                  Payments processed through Rise Works
                 </p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <div className="w-8 h-8 rounded-lg bg-muted/20 flex items-center justify-center flex-shrink-0">
-                <Landmark size={16} className="text-muted-foreground" />
-              </div>
-              <div>
-                <p className="text-xs text-muted-foreground">Bank Transfer</p>
-                <p className="text-sm font-medium text-foreground">1-3 days</p>
               </div>
             </div>
           </div>
@@ -230,6 +218,27 @@ const DashboardPayouts = () => {
               ))}
             </TableBody>
           </Table>
+        </div>
+
+        {/* Rise Works Info */}
+        <div className="rounded-2xl bg-card/30 backdrop-blur-sm border border-border/30 p-5 space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+              <Info size={16} className="text-primary" />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Payouts at Dynasty Futures are processed through Rise Works, a third-party payment provider. Rise handles payment processing, compliance, and verification to ensure all payouts are secure and accurate.
+            </p>
+          </div>
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+              <Info size={16} className="text-primary" />
+            </div>
+            <div className="text-sm text-muted-foreground space-y-2">
+              <p>To receive a payout, traders may be required to complete identity and payment verification through Rise Works. This process helps protect both the trader and the platform.</p>
+              <p>Payouts are not arbitrarily denied. As long as your information is accurate and verification is completed successfully, your payout will be processed. Issues only arise in cases of incomplete verification or fraudulent information.</p>
+            </div>
+          </div>
         </div>
 
         {/* Payout History */}


### PR DESCRIPTION
## Summary

- **Payout Quick Reference** (`DashboardPayouts.tsx`): Replaced "Wise Transfer" and "Bank Transfer" method entries with a single "Payments processed through Rise Works" entry, preserving grid layout using `col-span-2`
- **Payout History table** (`DashboardPayouts.tsx`): Updated all `method` values from "Wise Transfer" / "Bank Transfer" to "Rise Works"; updated `getMethodIcon` accordingly
- **Rise Works info section** (`DashboardPayouts.tsx`): Added an informational card between the Eligible Accounts table and Payout History explaining Rise Works as the payment processor, verification requirements, and payout approval policy — using the exact provided copy
- **FAQ "How do payouts work?"** (`FAQ.tsx`): Added a new FAQ entry with full Rise Works explanation and verification/approval details
- **FAQ "When do payouts happen?"** (`FAQ.tsx`): Appended the Rise Works processing sentence to the existing answer

## Test plan

- [ ] Visit `/dashboard/payouts` — confirm Quick Reference shows "Payments processed through Rise Works" (no Wise/Bank Transfer entries)
- [ ] Confirm payout history Method column shows "Rise Works" for all rows
- [ ] Confirm the Rise Works info section appears between Eligible Accounts and Payout History with correct copy
- [ ] Visit `/faq` — confirm new "How do payouts work?" accordion item is present with correct content
- [ ] Confirm "When do payouts happen?" answer ends with the Rise Works sentence
- [ ] Confirm no styling, spacing, or layout regressions on either page

https://claude.ai/code/session_01EZJNri2LBxpt8YacX8fJve