### PR TITLE
feat: footer social icons, Discord CTA section, dashboard year update

### DIFF
--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -96,7 +96,7 @@ const DashboardSidebar = () => {
         {/* Footer */}
         <div className="p-2 border-t border-border/30">
         <p className="text-[10px] text-muted-foreground text-center">
-          © 2025
+          © 2026
         </p>
         </div>
       </aside>

--- a/src/components/home/DiscordCTA.tsx
+++ b/src/components/home/DiscordCTA.tsx
@@ -1,0 +1,76 @@
+import { Button } from "@/components/ui/button";
+import ScrollReveal from "@/components/ui/ScrollReveal";
+
+const DiscordCTA = () => {
+  return (
+    <section className="py-20 md:py-32 relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-card/20 to-transparent" />
+
+      <div className="container mx-auto px-4 relative z-10">
+        <ScrollReveal className="flex flex-col items-center text-center max-w-2xl mx-auto">
+          {/* Gold Discord Icon */}
+          <div className="mb-8 relative">
+            <div
+              className="absolute inset-0 rounded-full blur-2xl opacity-30"
+              style={{
+                background:
+                  "radial-gradient(circle, hsl(43 74% 49%) 0%, transparent 70%)",
+              }}
+            />
+            <svg
+              className="w-20 h-20 md:w-24 md:h-24 relative z-10 drop-shadow-lg"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <defs>
+                <linearGradient
+                  id="discordGoldGrad"
+                  x1="0%"
+                  y1="0%"
+                  x2="100%"
+                  y2="100%"
+                >
+                  <stop offset="0%" stopColor="hsl(43 74% 60%)" />
+                  <stop offset="50%" stopColor="hsl(43 74% 49%)" />
+                  <stop offset="100%" stopColor="hsl(35 55% 35%)" />
+                </linearGradient>
+              </defs>
+              <path
+                fill="url(#discordGoldGrad)"
+                d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.1 18.079.12 18.1.138 18.112a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"
+              />
+            </svg>
+          </div>
+
+          {/* Heading */}
+          <h2 className="font-display text-3xl md:text-4xl lg:text-5xl font-bold mb-4">
+            Join the <span className="text-gradient-animated">Discord</span>
+          </h2>
+
+          {/* Supporting sentence */}
+          <p className="text-lg text-muted-foreground mb-8 max-w-md">
+            Connect with the community, get support, and stay up to date.
+          </p>
+
+          {/* CTA Button */}
+          <Button
+            size="lg"
+            className="btn-gradient-animated text-primary-foreground font-semibold px-8 py-6 text-lg btn-glow transition-all duration-300 hover:shadow-lg hover:shadow-primary/30"
+            asChild
+          >
+            <a
+              href="https://discord.gg/CMwf9Nsysq"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Join the Discord
+            </a>
+          </Button>
+        </ScrollReveal>
+      </div>
+    </section>
+  );
+};
+
+export default DiscordCTA;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -43,11 +43,60 @@ const Footer = () => {
                 />
               </Link>
             </div>
-            <p className="text-muted-foreground text-sm leading-relaxed">
-              Dynasty Futures LLC is a proprietary trading firm registered in
-              Wyoming, offering simulated funded accounts to qualified futures
-              traders.
-            </p>
+            <div>
+              <p className="text-muted-foreground text-sm leading-relaxed mb-4">
+                Dynasty Futures LLC is a proprietary trading firm registered in
+                Wyoming, offering simulated funded accounts to qualified futures
+                traders.
+              </p>
+              {/* Social Icons */}
+              <div className="flex items-center gap-3">
+                <a
+                  href="https://www.instagram.com/dynastyfutures"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Instagram"
+                  className="text-muted-foreground hover:text-primary transition-colors duration-300"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z" />
+                  </svg>
+                </a>
+                <a
+                  href="https://x.com/dynastyfutures"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="X (Twitter)"
+                  className="text-muted-foreground hover:text-primary transition-colors duration-300"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+                  </svg>
+                </a>
+                <a
+                  href="https://discord.gg/CMwf9Nsysq"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Discord"
+                  className="text-muted-foreground hover:text-primary transition-colors duration-300"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.1 18.079.12 18.1.138 18.112a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z" />
+                  </svg>
+                </a>
+                <a
+                  href="https://www.linkedin.com/company/dynasty-futures"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="LinkedIn"
+                  className="text-muted-foreground hover:text-primary transition-colors duration-300"
+                >
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                  </svg>
+                </a>
+              </div>
+            </div>
           </div>
 
           {/* Quick Links */}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,7 @@ import JsonLd, { organizationSchema, websiteSchema, breadcrumb } from '@/compone
 import Hero from '@/components/home/Hero';
 import FundingModels from '@/components/home/FundingModels';
 import HowItWorks from '@/components/home/HowItWorks';
+import DiscordCTA from '@/components/home/DiscordCTA';
 import SimulatedTrading from '@/components/home/SimulatedTrading';
 import PreLaunchModal from '@/components/PreLaunchModal';
 import SponsorTicker, { DefaultSponsors } from '@/components/ui/SponsorTicker';
@@ -52,6 +53,7 @@ const Index = () => {
         
         <FundingModels />
         <HowItWorks />
+        <DiscordCTA />
         <SimulatedTrading />
       </div>
     </Layout>


### PR DESCRIPTION
## Summary

- **Footer — Social icons:** Added Instagram, X (Twitter), Discord, and LinkedIn inline SVG icons to the footer's first column, below the company description. Icons use `text-muted-foreground` at rest and transition to `text-primary` (gold) on hover, matching the site's existing link hover behavior.
- **Home page — Discord CTA section:** Created `DiscordCTA.tsx` and inserted it between `HowItWorks` and `SimulatedTrading` on the home page. Includes a gold gradient Discord SVG icon with glow, "Join the Discord" heading with animated gradient text, a short supporting sentence, and a `btn-gradient-animated` CTA button linking to `https://discord.gg/CMwf9Nsysq`. Section sizing and spacing match existing homepage sections.
- **Dashboard sidebar — year:** Updated hardcoded `© 2025` to `© 2026` in `DashboardSidebar.tsx`.

## Files changed

| File | Change |
|------|--------|
| `src/components/layout/Footer.tsx` | Social icons row added below description text |
| `src/components/home/DiscordCTA.tsx` | New component (created) |
| `src/pages/Index.tsx` | Import + render `DiscordCTA` after `HowItWorks` |
| `src/components/dashboard/DashboardSidebar.tsx` | Year updated 2025 → 2026 |

## Test plan

- [ ] Home page: verify Discord CTA section appears between "How It Works" and the next section; confirm button opens `https://discord.gg/CMwf9Nsysq` in a new tab
- [ ] Footer: verify all four social icons render and hover gold on desktop and mobile
- [ ] Dashboard: verify sidebar bottom shows `© 2026`
- [ ] Confirm no existing footer text, disclaimers, or layout sections were removed or altered

https://claude.ai/code/session_01KsnWQ28QAZjDUgkQJK82yz