### PR TITLE
Update pricing, Builder MLL, rules copy, and remove homepage disclaimer

### DIFF
--- a/src/components/home/HowItWorks.tsx
+++ b/src/components/home/HowItWorks.tsx
@@ -132,15 +132,6 @@ const HowItWorks = () => {
           })}
         </div>
 
-        {/* Disclaimer */}
-        <ScrollReveal className="max-w-3xl mx-auto text-center">
-          <p className="text-xs text-muted-foreground glass-card rounded-xl px-6 py-4 border border-border/30">
-            All trading on Dynasty Futures is simulated. Payouts are based on
-            simulated trading performance only. No real trading occurs and no
-            real capital is ever at risk. Past simulated performance does not
-            guarantee future results.
-          </p>
-        </ScrollReveal>
       </div>
     </section>
   );

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -89,12 +89,12 @@ export const productSchemas = [
     '@type': 'Product',
     name: 'Dynasty Futures Standard Plan — $25K',
     description:
-      'Standard evaluation plan with a $25,000 simulated account. $49 evaluation fee, $80 activation fee.',
+      'Standard evaluation plan with a $25,000 simulated account. $59 evaluation fee, $80 activation fee.',
     brand: { '@type': 'Brand', name: 'Dynasty Futures' },
     image: `${BASE_URL}/standardplan.webp`,
     offers: {
       '@type': 'Offer',
-      price: '49',
+      price: '59',
       priceCurrency: 'USD',
       url: `${BASE_URL}/pricing#standard`,
       availability: 'https://schema.org/InStock',

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -31,7 +31,7 @@ import { toast } from "sonner";
 const standardPricing = [
   {
     size: "$25,000",
-    evalFee: "$49",
+    evalFee: "$59",
     activationFee: "$80",
     evalReset: "$25",
     fundedReset: "$359",
@@ -157,12 +157,12 @@ const builderRules = {
   },
   "$100,000": {
     profitTarget: "$6,000",
-    maxDrawdown: "$3,500",
+    maxDrawdown: "$4,000",
     dailyLoss: "$2,000",
   },
   "$150,000": {
     profitTarget: "$9,000",
-    maxDrawdown: "$5,000",
+    maxDrawdown: "$5,500",
     dailyLoss: "$3,000",
   },
 };
@@ -272,6 +272,9 @@ const Pricing = () => {
               <p className="text-lg text-muted-foreground">
                 Choose the plan that fits your trading style. Plans include
                 static drawdown with plan-specific consistency requirements.
+              </p>
+              <p className="text-sm text-muted-foreground/80 mt-3">
+                Max allocation is currently limited to 2 accounts per trader. This limit is expected to increase as the firm continues to grow.
               </p>
             </ScrollReveal>
 

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -166,14 +166,14 @@ const accountRules = [
     size: "100K Account",
     profitTarget: "$6,000",
     standardAdvancedMaxDrawdown: "$3,000",
-    builderMaxDrawdown: "$3,500",
+    builderMaxDrawdown: "$4,000",
     dailyLoss: "$2,000",
   },
   {
     size: "150K Account",
     profitTarget: "$9,000",
     standardAdvancedMaxDrawdown: "$4,500",
-    builderMaxDrawdown: "$5,000",
+    builderMaxDrawdown: "$5,500",
     dailyLoss: "$3,000",
   },
 ];
@@ -679,76 +679,25 @@ const Rules = () => {
             </ScrollReveal>
           </section>
 
-          {/* Builder Plan Rules Summary */}
+          {/* Builder Plan */}
           <section className="mb-20">
             <ScrollReveal delay={0}>
               <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground mb-8 flex items-center gap-3">
                 <span className="text-gradient-animated">
-                  Builder Plan Rules Summary
+                  Builder Plan
                 </span>
               </h2>
             </ScrollReveal>
 
             <ScrollReveal delay={150}>
               <div className="bg-gradient-card rounded-2xl border border-border/50 overflow-hidden">
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead>
-                      <tr className="border-b border-border/30 bg-muted/10">
-                        <th className="text-left py-4 px-6 text-foreground font-semibold">
-                          Rule
-                        </th>
-                        <th className="text-left py-4 px-6 text-foreground font-semibold">
-                          Details
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Consistency Rule
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          50% consistency rule applies during the evaluation
-                          phase.
-                        </td>
-                      </tr>
-                      <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Activation Fee
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          No activation fee is required after passing.
-                        </td>
-                      </tr>
-                      <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Payout Cycle
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          Builder uses the 5-day payout cycle.
-                        </td>
-                      </tr>
-                      <tr className="border-b border-border/20 hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Max Loss Limit
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          Builder max loss limits are $500 higher than Standard
-                          for each account size.
-                        </td>
-                      </tr>
-                      <tr className="hover:bg-muted/10 transition-colors">
-                        <td className="py-4 px-6 text-primary font-medium">
-                          Positioning
-                        </td>
-                        <td className="py-4 px-6 text-muted-foreground">
-                          Builder is designed for traders who want more room to
-                          execute with structured risk controls.
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                <div className="p-8 md:p-10 space-y-5">
+                  <p className="text-muted-foreground">
+                    Builder Plan is designed for traders who want more room to operate. With higher maximum loss limits, traders have increased flexibility to manage positions, navigate volatility, and avoid getting stopped out prematurely.
+                  </p>
+                  <p className="text-muted-foreground">
+                    At Dynasty Futures, we are focused on building structures that give traders a real opportunity to succeed. The Builder Plan reflects that philosophy by prioritizing sustainability, flexibility, and long-term consistency over restrictive conditions.
+                  </p>
                 </div>
               </div>
             </ScrollReveal>


### PR DESCRIPTION
## Summary

- **Standard 25K eval fee**: $49 → $59 (pricing card, SEO schema)
- **Builder Plan MLL increase (+$500)**: 100K $3,500 → $4,000 · 150K $5,000 → $5,500 (pricing table + rules page account cards)
- **Max allocation notice**: Added subtle line under "Pricing & Plans" heading
- **Builder Plan section (Rules page)**: Replaced rules summary table with marketing-focused copy per exact brief
- **Homepage**: Removed simulated trading disclaimer box from "How It Works" section

All values are consistent across `Pricing.tsx`, `Rules.tsx`, and `JsonLd.tsx`. No layout, styling, or unrelated content was changed.

## Test plan

- [ ] Pricing page — Standard 25K row shows $59
- [ ] Pricing page — Builder 100K MLL shows $4,000, Builder 150K MLL shows $5,500
- [ ] Pricing page — Max allocation notice appears under heading, subtle and readable
- [ ] Rules page — Account cards for 100K and 150K show updated Builder Max Loss values
- [ ] Rules page — Builder Plan section shows marketing copy (no table)
- [ ] Home page — "How It Works" section has no disclaimer box; layout looks clean

https://claude.ai/code/session_018ma5CJykdpanwH6rS668uZ