### PR TITLE
Update About page LinkedIn icons to match footer SVG

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -13,7 +13,6 @@ import {
   Clock,
   MapPin,
   Building2,
-  Linkedin,
 } from "lucide-react";
 
 const differentiators = [
@@ -364,7 +363,9 @@ const About = () => {
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-2 mt-6 text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  <Linkedin className="w-4 h-4" />
+                  <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                  </svg>
                   <span>Connect with me on LinkedIn</span>
                 </a>
               </div>
@@ -427,7 +428,9 @@ const About = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 mt-6 text-sm text-muted-foreground hover:text-primary transition-colors"
                   >
-                    <Linkedin className="w-4 h-4" />
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
                     <span>Connect with me on LinkedIn</span>
                   </a>
                 </div>
@@ -473,7 +476,9 @@ const About = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
                   >
-                    <Linkedin className="w-4 h-4" />
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
                     <span>Connect with me on LinkedIn</span>
                   </a>
                 </div>


### PR DESCRIPTION
## Summary

- Replaces the lucide-react `<Linkedin>` component (`w-4 h-4`) in all three founder bio sections on the About page with the identical custom inline SVG (`w-5 h-5`) already used in the site footer
- Removes the now-unused `Linkedin` import from lucide-react
- Layout, text, spacing, and hover behavior are unchanged

## Test plan

- [ ] Visit `/about` and confirm all three "Connect with me on LinkedIn" links display the same icon shape as the footer LinkedIn icon
- [ ] Confirm icon size and visual weight feel consistent with the footer
- [ ] Confirm hover color change still works on all three links
- [ ] Confirm no other icons or page sections were affected

https://claude.ai/code/session_01EkGBo4aG5JkzA13H6gwo3j