### PR TITLE
Update homepage hero button text and links

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -155,7 +155,7 @@ const Hero = () => {
                 asChild
               >
                 <Link to="/pricing" onClick={handleClick}>
-                  Start Challenge
+                  View Dynasty Plans
                   <ArrowRight className="ml-2 w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" />
                 </Link>
               </Button>
@@ -165,9 +165,9 @@ const Hero = () => {
                 className="border-primary/30 bg-card/40 backdrop-blur-sm px-8 py-6 text-lg hover:bg-primary/10 hover:border-primary/50 transition-all duration-300"
                 asChild
               >
-                <Link to="/pricing" onClick={handleClick}>
-                  View Pricing & Plans
-                </Link>
+                <a href="https://discord.gg/CMwf9Nsysq" target="_blank" rel="noopener noreferrer">
+                  Join Our Community
+                </a>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Left gold button: text changed from "Start Challenge" → "View Dynasty Plans", still links to `/pricing`
- Right outlined button: text changed from "View Pricing & Plans" → "Join Our Community", now links to `https://discord.gg/CMwf9Nsysq` (opens in new tab)

## Test plan

- [ ] Verify left button displays "View Dynasty Plans" and navigates to `/pricing`
- [ ] Verify right button displays "Join Our Community" and opens `https://discord.gg/CMwf9Nsysq` in a new tab
- [ ] Confirm no other layout, spacing, or styling changes on the hero section

https://claude.ai/code/session_01JpX8h27QgrRT3v9XGAtcNE