### PR TITLE
Update pricing plans, MLL, profit targets, and plan rules

### DIFF
--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -106,12 +106,12 @@ export const productSchemas = [
     '@type': 'Product',
     name: 'Dynasty Futures Standard Plan — $50K',
     description:
-      'Standard evaluation plan with a $50,000 simulated account. $69 evaluation fee, $80 activation fee.',
+      'Standard evaluation plan with a $50,000 simulated account. $79 evaluation fee, $80 activation fee.',
     brand: { '@type': 'Brand', name: 'Dynasty Futures' },
     image: `${BASE_URL}/standardplan.webp`,
     offers: {
       '@type': 'Offer',
-      price: '69',
+      price: '79',
       priceCurrency: 'USD',
       url: `${BASE_URL}/pricing#standard`,
       availability: 'https://schema.org/InStock',
@@ -123,12 +123,12 @@ export const productSchemas = [
     '@type': 'Product',
     name: 'Dynasty Futures Standard Plan — $100K',
     description:
-      'Standard evaluation plan with a $100,000 simulated account. $119 evaluation fee, $80 activation fee.',
+      'Standard evaluation plan with a $100,000 simulated account. $129 evaluation fee, $80 activation fee.',
     brand: { '@type': 'Brand', name: 'Dynasty Futures' },
     image: `${BASE_URL}/standardplan.webp`,
     offers: {
       '@type': 'Offer',
-      price: '119',
+      price: '129',
       priceCurrency: 'USD',
       url: `${BASE_URL}/pricing#standard`,
       availability: 'https://schema.org/InStock',
@@ -140,12 +140,12 @@ export const productSchemas = [
     '@type': 'Product',
     name: 'Dynasty Futures Standard Plan — $150K',
     description:
-      'Standard evaluation plan with a $150,000 simulated account. $149 evaluation fee, $80 activation fee.',
+      'Standard evaluation plan with a $150,000 simulated account. $159 evaluation fee, $80 activation fee.',
     brand: { '@type': 'Brand', name: 'Dynasty Futures' },
     image: `${BASE_URL}/standardplan.webp`,
     offers: {
       '@type': 'Offer',
-      price: '149',
+      price: '159',
       priceCurrency: 'USD',
       url: `${BASE_URL}/pricing#standard`,
       availability: 'https://schema.org/InStock',

--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -41,7 +41,7 @@ const faqs = [
     id: "static-drawdown",
     question: "What is a static drawdown?",
     answer:
-      "Static drawdown is a fixed maximum loss limit that doesn't trail your account's peak equity. For example, if you have a $100,000 account with a $3,000 static drawdown, your account will be violated if your balance drops below $97,000 at any point. This level stays constant regardless of profits made, giving you more flexibility than trailing drawdown systems.",
+      "Static drawdown is a fixed maximum loss limit that doesn't trail your account's peak equity. For example, if you have a $100,000 account with a $2,500 static drawdown, your account will be violated if your balance drops below $97,500 at any point. This level stays constant regardless of profits made, giving you more flexibility than trailing drawdown systems.",
   },
   {
     id: "post-payout-drawdown",
@@ -83,7 +83,7 @@ const faqs = [
     id: "consistency",
     question: "Is there a consistency rule?",
     answer:
-      "Yes, on Standard and Builder during evaluation.\n\nBoth Standard and Builder include a 50% consistency rule during the evaluation phase, meaning no single trading day may account for more than 50% of the total profit target.\n\nOnce the evaluation is passed and the account is approved for funding, the consistency rule is removed.\n\nAdvanced does not include a consistency rule, and no funded accounts are subject to a consistency rule.",
+      "Yes, on Standard and Builder, with different rules for each.\n\nStandard includes a 50% consistency rule during the evaluation phase only, meaning no single trading day may account for more than 50% of the total profit target. The consistency rule is removed once funded.\n\nBuilder includes a 40% consistency rule during both the evaluation phase and the funded stage, meaning no single trading day may account for more than 40% of the total profit target in either phase.\n\nAdvanced does not include a consistency rule.",
   },
   {
     id: "getting-started",
@@ -95,7 +95,7 @@ const faqs = [
     id: "profit-target",
     question: "What is the profit target?",
     answer:
-      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $9,000. Once you reach your profit target while following all rules, you pass the challenge.",
+      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $8,000. Once you reach your profit target while following all rules, you pass the challenge.",
   },
   {
     id: "five-payouts",

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -33,29 +33,29 @@ const standardPricing = [
     size: "$25,000",
     evalFee: "$59",
     activationFee: "$80",
-    evalReset: "$25",
-    fundedReset: "$359",
+    evalReset: "$30",
+    fundedReset: "$119",
   },
   {
     size: "$50,000",
-    evalFee: "$69",
+    evalFee: "$79",
     activationFee: "$80",
-    evalReset: "$33",
-    fundedReset: "$509",
+    evalReset: "$40",
+    fundedReset: "$159",
   },
   {
     size: "$100,000",
-    evalFee: "$119",
+    evalFee: "$129",
     activationFee: "$80",
-    evalReset: "$54",
-    fundedReset: "$789",
+    evalReset: "$65",
+    fundedReset: "$259",
   },
   {
     size: "$150,000",
-    evalFee: "$149",
+    evalFee: "$159",
     activationFee: "$80",
-    evalReset: "$63",
-    fundedReset: "$1,079",
+    evalReset: "$80",
+    fundedReset: "$319",
   },
 ];
 
@@ -64,29 +64,29 @@ const advancedPricing = [
     size: "$25,000",
     evalFee: "$79",
     activationFee: "$0",
-    evalReset: "$49",
-    fundedReset: "$369",
+    evalReset: "$40",
+    fundedReset: "$159",
   },
   {
     size: "$50,000",
     evalFee: "$109",
     activationFee: "$0",
-    evalReset: "$65",
-    fundedReset: "$529",
+    evalReset: "$55",
+    fundedReset: "$219",
   },
   {
     size: "$100,000",
     evalFee: "$179",
     activationFee: "$0",
-    evalReset: "$103",
-    fundedReset: "$819",
+    evalReset: "$90",
+    fundedReset: "$359",
   },
   {
     size: "$150,000",
     evalFee: "$229",
     activationFee: "$0",
-    evalReset: "$126",
-    fundedReset: "$1,119",
+    evalReset: "$115",
+    fundedReset: "$459",
   },
 ];
 
@@ -95,29 +95,29 @@ const builderPricing = [
     size: "$25,000",
     evalFee: "$109",
     activationFee: "$0",
-    evalReset: "$60",
-    fundedReset: "$379",
+    evalReset: "$55",
+    fundedReset: "$219",
   },
   {
     size: "$50,000",
     evalFee: "$149",
     activationFee: "$0",
-    evalReset: "$78",
-    fundedReset: "$539",
+    evalReset: "$75",
+    fundedReset: "$299",
   },
   {
     size: "$100,000",
     evalFee: "$239",
     activationFee: "$0",
-    evalReset: "$119",
-    fundedReset: "$839",
+    evalReset: "$120",
+    fundedReset: "$479",
   },
   {
     size: "$150,000",
     evalFee: "$299",
     activationFee: "$0",
-    evalReset: "$142",
-    fundedReset: "$1,149",
+    evalReset: "$150",
+    fundedReset: "$599",
   },
 ];
 
@@ -134,12 +134,12 @@ const standardAdvancedRules = {
   },
   "$100,000": {
     profitTarget: "$6,000",
-    maxDrawdown: "$3,000",
+    maxDrawdown: "$2,500",
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$9,000",
-    maxDrawdown: "$4,500",
+    profitTarget: "$8,000",
+    maxDrawdown: "$4,000",
     dailyLoss: "$3,000",
   },
 };
@@ -157,12 +157,12 @@ const builderRules = {
   },
   "$100,000": {
     profitTarget: "$6,000",
-    maxDrawdown: "$4,000",
+    maxDrawdown: "$3,500",
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$9,000",
-    maxDrawdown: "$5,500",
+    profitTarget: "$8,000",
+    maxDrawdown: "$5,000",
     dailyLoss: "$3,000",
   },
 };
@@ -438,6 +438,12 @@ const Pricing = () => {
                         Overnight trading allowed
                       </span>
                     </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ShieldIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        One funded reset allowed per account
+                      </span>
+                    </div>
                   </div>
                   <p className="text-sm text-muted-foreground mt-6 text-center">
                     All plans renew monthly. Cancel anytime. Reset fees are
@@ -600,6 +606,12 @@ const Pricing = () => {
                         Priority support
                       </span>
                     </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ShieldIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        One funded reset allowed per account
+                      </span>
+                    </div>
                   </div>
                   <p className="text-sm text-muted-foreground mt-6 text-center">
                     All plans renew monthly. Cancel anytime.
@@ -751,7 +763,7 @@ const Pricing = () => {
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
                       <CheckIcon size={20} />
                       <span className="text-sm text-foreground">
-                        50% consistency rule (evaluation only)
+                        40% consistency rule (evaluation and funded)
                       </span>
                     </div>
                     <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
@@ -764,6 +776,12 @@ const Pricing = () => {
                       <DollarIcon size={20} />
                       <span className="text-sm text-foreground">
                         No activation fee
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-3 p-4 rounded-xl bg-muted/15 backdrop-blur-sm border border-border/20">
+                      <ShieldIcon size={20} />
+                      <span className="text-sm text-foreground">
+                        One funded reset allowed per account
                       </span>
                     </div>
                   </div>

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -165,15 +165,15 @@ const accountRules = [
   {
     size: "100K Account",
     profitTarget: "$6,000",
-    standardAdvancedMaxDrawdown: "$3,000",
-    builderMaxDrawdown: "$4,000",
+    standardAdvancedMaxDrawdown: "$2,500",
+    builderMaxDrawdown: "$3,500",
     dailyLoss: "$2,000",
   },
   {
     size: "150K Account",
-    profitTarget: "$9,000",
-    standardAdvancedMaxDrawdown: "$4,500",
-    builderMaxDrawdown: "$5,500",
+    profitTarget: "$8,000",
+    standardAdvancedMaxDrawdown: "$4,000",
+    builderMaxDrawdown: "$5,000",
     dailyLoss: "$3,000",
   },
 ];
@@ -188,6 +188,7 @@ const planRules = [
       "50% consistency rule (evaluation only)",
       "5-day payout cycles",
       "Copy trading allowed",
+      "One funded reset allowed per account",
     ],
     eligibility:
       "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $150 or more.",
@@ -203,6 +204,7 @@ const planRules = [
       "5-day payout cycles",
       "Priority support",
       "Copy trading allowed",
+      "One funded reset allowed per account",
     ],
     eligibility:
       "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $200 or more.",
@@ -212,11 +214,12 @@ const planRules = [
     tagline: "More Room to Execute",
     features: [
       "Higher max loss limit than Standard",
-      "50% consistency rule (evaluation phase)",
+      "40% consistency rule (evaluation and funded)",
       "No activation fee",
       "5-day payout cycles",
       "Static drawdown",
       "Copy trading allowed",
+      "One funded reset allowed per account",
     ],
     eligibility:
       "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $200 or more.",
@@ -665,9 +668,9 @@ const Rules = () => {
                     drawdown remains constant.
                   </p>
                   <p className="text-muted-foreground mb-4">
-                    For example, if you have a $100,000 account with a $3,000
+                    For example, if you have a $100,000 account with a $2,500
                     static drawdown, your account will be violated if your
-                    balance drops below $97,000 at any point. This level does
+                    balance drops below $97,500 at any point. This level does
                     not change regardless of how much profit you make.
                   </p>
                   <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary

- **Standard plan**: Updated eval fees ($59/$79/$129/$159), eval resets to 50%-of-eval rule ($30/$40/$65/$80), and funded resets reduced ($119/$159/$259/$319). Added $80 activation fee messaging and one-funded-reset-per-account chip.
- **Advanced plan**: Updated eval resets ($40/$55/$90/$115) and funded resets ($159/$219/$359/$459). Added one-funded-reset-per-account chip.
- **Builder plan**: Updated eval resets ($55/$75/$120/$150) and funded resets ($219/$299/$479/$599). Changed consistency rule from 50% eval-only to 40% evaluation and funded. Added one-funded-reset-per-account chip.
- **MLL updates**: Standard/Advanced $100K $3,000→$2,500, $150K $4,500→$4,000. Builder $100K $4,000→$3,500, $150K $5,500→$5,000.
- **Profit target**: $150K changed from $9,000 to $8,000 across all plans.
- **Rules page**: Account-Specific Rules updated with new MLL/profit target values. Plan Rules updated with Builder 40% consistency rule (eval + funded) and one-funded-reset rule on all three plans.
- **FAQ**: Consistency rule answer updated for Builder (40%, both phases). Profit target $150K updated to $8,000. Static drawdown example updated to $2,500/$97,500.
- **SEO schemas (JsonLd)**: Standard plan $50K/$100K/$150K descriptions and offer prices updated.

## Test plan

- [ ] Visit `/pricing` — verify Standard, Advanced, Builder tables show new eval fees, eval resets, funded resets, MLL, and profit targets
- [ ] Confirm Standard shows $80 activation fee; Advanced and Builder show $0
- [ ] Confirm Standard chips show 50% consistency rule (eval only) and one funded reset per account
- [ ] Confirm Builder chips show 40% consistency rule (evaluation and funded) and one funded reset per account
- [ ] Visit `/rules` — verify Account-Specific Rules cards show updated $100K ($2,500/$3,500) and $150K ($8,000/$4,000/$5,000) values
- [ ] Confirm Plan Rules cards show updated Builder 40% consistency rule and one-funded-reset rule on all three plans
- [ ] Visit `/faq` — verify consistency rule answer reflects Builder 40% (both phases), profit target answer shows $8,000 for $150K, static drawdown example shows $2,500/$97,500
- [ ] Verify no old pricing values remain anywhere in the UI

https://claude.ai/code/session_01XFnAipSTqjwQjY8UJdjtWP