### PR TITLE
Fix Builder Plan consistency rule wording on Rules and FAQ pages

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -83,7 +83,7 @@ const faqs = [
     id: "consistency",
     question: "Is there a consistency rule?",
     answer:
-      "Yes, on Standard and Builder, with different rules for each.\n\nStandard includes a 50% consistency rule during the evaluation phase only, meaning no single trading day may account for more than 50% of the total profit target. The consistency rule is removed once funded.\n\nBuilder includes a 40% consistency rule during both the evaluation phase and the funded stage, meaning no single trading day may account for more than 40% of the total profit target in either phase.\n\nAdvanced does not include a consistency rule.",
+      "Yes, on Standard and Builder, with different rules for each. Standard includes a 50% consistency rule during the evaluation phase only, meaning no single trading day may account for more than 50% of the total profit target. The consistency rule is removed once funded. Builder includes a 50% consistency rule during the evaluation phase and a 40% consistency rule during the funded stage, meaning no single trading day may account for more than 40% of the total profit target in the funded phase. Advanced does not include a consistency rule.",
   },
   {
     id: "getting-started",

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -214,7 +214,7 @@ const planRules = [
     tagline: "More Room to Execute",
     features: [
       "Higher max loss limit than Standard",
-      "40% consistency rule (evaluation and funded)",
+      "50% consistency rule (evaluation) / 40% consistency rule (funded)",
       "No activation fee",
       "5-day payout cycles",
       "Static drawdown",


### PR DESCRIPTION
## Summary

- **Rules page**: Updated the Builder Plan feature list entry from `"40% consistency rule (evaluation and funded)"` to `"50% consistency rule (evaluation) / 40% consistency rule (funded)"` to correctly reflect the two distinct rates per stage.
- **FAQ page**: Replaced the answer to "Is there a consistency rule?" with the exact approved text, clarifying that Builder uses 50% during evaluation and 40% during the funded stage (previously the answer incorrectly stated 40% for both phases).

## Test plan

- [ ] Visit `/rules` — confirm Builder Plan feature list shows `50% consistency rule (evaluation) / 40% consistency rule (funded)`
- [ ] Visit `/faq` — confirm the "Is there a consistency rule?" answer matches the new approved text exactly
- [ ] Confirm no other text, styling, or layout was changed on either page

https://claude.ai/code/session_01187UAiWyLGEKKEJLV86HW5