### PR TITLE
fix(seo): pre-render /about and /affiliates for full bot crawlability

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,30 +2,26 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.dynastyfuturesdyn.com/</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-04-20</lastmod>
   </url>
   <url>
     <loc>https://www.dynastyfuturesdyn.com/pricing</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-04-20</lastmod>
   </url>
   <url>
     <loc>https://www.dynastyfuturesdyn.com/rules</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-04-20</lastmod>
   </url>
   <url>
     <loc>https://www.dynastyfuturesdyn.com/faq</loc>
-    <lastmod>2026-04-09</lastmod>
-  </url>
-  <url>
-    <loc>https://www.dynastyfuturesdyn.com/support</loc>
-    <lastmod>2026-04-09</lastmod>
-  </url>
-  <url>
-    <loc>https://www.dynastyfuturesdyn.com/legal</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-04-20</lastmod>
   </url>
   <url>
     <loc>https://www.dynastyfuturesdyn.com/about</loc>
-    <lastmod>2026-04-09</lastmod>
+    <lastmod>2026-04-20</lastmod>
+  </url>
+  <url>
+    <loc>https://www.dynastyfuturesdyn.com/affiliates</loc>
+    <lastmod>2026-04-20</lastmod>
   </url>
 </urlset>

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -22,7 +22,9 @@ const PUBLIC_ROUTES = [
   '/support',
   '/legal',
   '/login',
-  '/register'
+  '/register',
+  '/about',
+  '/affiliates',
 ];
 
 async function prerender() {

--- a/src/components/seo/PageMeta.tsx
+++ b/src/components/seo/PageMeta.tsx
@@ -11,10 +11,12 @@ interface PageMetaProps {
   path: string;
   ogImage?: string;
   noIndex?: boolean;
+  /** Provide a fully-formed title string to bypass the automatic "| Dynasty Futures" suffix */
+  rawTitle?: string;
 }
 
-const PageMeta = ({ title, description, path, ogImage, noIndex }: PageMetaProps) => {
-  const fullTitle = path === '/' ? title : `${title} | ${SITE_NAME}`;
+const PageMeta = ({ title, description, path, ogImage, noIndex, rawTitle }: PageMetaProps) => {
+  const fullTitle = rawTitle ?? (path === '/' ? title : `${title} | ${SITE_NAME}`);
   const canonicalUrl = `${BASE_URL}${path}`;
   const image = ogImage || DEFAULT_OG_IMAGE;
 

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -19,6 +19,8 @@ import Legal from './pages/Legal';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Payouts from './pages/Payouts';
+import About from './pages/About';
+import Affiliates from './pages/Affiliates';
 import NotFound from './pages/NotFound';
 
 const ServerRoutes = () => (
@@ -32,6 +34,8 @@ const ServerRoutes = () => (
     <Route path="/login" element={<Login />} />
     <Route path="/register" element={<Register />} />
     <Route path="/payouts" element={<Payouts />} />
+    <Route path="/about" element={<About />} />
+    <Route path="/affiliates" element={<Affiliates />} />
     <Route path="*" element={<NotFound />} />
   </Routes>
 );

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import Layout from "@/components/layout/Layout";
 import PageMeta from "@/components/seo/PageMeta";
 import JsonLd, { breadcrumb, organizationSchema } from "@/components/seo/JsonLd";
@@ -43,28 +42,11 @@ const differentiators = [
 ];
 
 const About = () => {
-  useEffect(() => {
-    document.title = "About Us | Dynasty Futures";
-    const meta = document.querySelector('meta[name="description"]');
-    const content =
-      "Dynasty Futures LLC is a Wyoming-registered proprietary trading firm built for traders who value clarity, discipline, and opportunity. Fair pricing, higher max loss flexibility, and honest payout transparency.";
-    if (meta) {
-      meta.setAttribute("content", content);
-    } else {
-      const tag = document.createElement("meta");
-      tag.name = "description";
-      tag.content = content;
-      document.head.appendChild(tag);
-    }
-    return () => {
-      document.title = "Dynasty Futures";
-    };
-  }, []);
-
   return (
     <Layout>
       <PageMeta
         title="About Us"
+        rawTitle="About Dynasty Futures | Our Mission & Leadership"
         description="Dynasty Futures is a proprietary trading firm built on fair pricing, higher max loss flexibility, and transparent payout structures for futures traders."
         path="/about"
       />

--- a/src/pages/Affiliates.tsx
+++ b/src/pages/Affiliates.tsx
@@ -191,6 +191,7 @@ const Affiliates = () => {
     <Layout>
       <PageMeta
         title="Affiliate Program"
+        rawTitle="Dynasty Futures Affiliate Program"
         description="Join the Dynasty Futures affiliate program. Earn 10% commission on every referred sale. Trade first, partner second. Built for traders, creators, and educators who believe in the platform."
         path="/affiliates"
       />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Pre-render /about and /affiliates as static HTML** — added both routes to `entry-server.tsx` and `scripts/prerender.ts` so the build emits `dist/about/index.html` and `dist/affiliates/index.html`. All page text is now present in raw HTML with zero JavaScript required; search engines and AI crawlers can read the full content on first byte.
- **Exact `<title>` tags** — added a `rawTitle` prop to `PageMeta` so pages can specify a fully-formed title without the automatic `| Dynasty Futures` suffix. About page now renders `"About Dynasty Futures | Our Mission & Leadership"` and Affiliates renders `"Dynasty Futures Affiliate Program"`.
- **Removed SSR-incompatible `useEffect`** from `About.tsx` that was manually manipulating `document.title` / `document.querySelector` — this code only runs in the browser, never during prerender, so it was redundant and potentially confusing. `react-helmet-async` handles all meta injection correctly for both SSR and client.
- **Sitemap updated** — `/affiliates` added, `/support` and `/legal` removed (auth/utility pages), all `lastmod` dates updated to 2026-04-20.

## What already existed (no changes needed)

- Navigation bar already links to `/about` and `/affiliates`
- Footer already links to both pages via standard `<a>` (React Router `<Link>`) tags
- `PageMeta` already emits full Open Graph + Twitter Card + canonical tags
- Structured data (`JsonLd`) already present on both pages

## Test plan

- [ ] Run `npm run build` — confirm no TypeScript errors and prerender completes for all routes including `/about` and `/affiliates`
- [ ] Open `dist/about/index.html` in a text editor — confirm all hero text, mission copy, and leadership names are present as plain HTML
- [ ] Open `dist/affiliates/index.html` — confirm tier names, commission details, and FAQ answers are present as plain HTML
- [ ] Confirm `<title>` in `dist/about/index.html` is exactly `About Dynasty Futures | Our Mission & Leadership`
- [ ] Confirm `<title>` in `dist/affiliates/index.html` is exactly `Dynasty Futures Affiliate Program`
- [ ] Verify `public/sitemap.xml` is served at `/sitemap.xml` and includes both `/about` and `/affiliates`

https://claude.ai/code/session_01TQoRCqzYXPX29MyRL1atWw
EOF
)