### PR TITLE
fix(rules): clarify drawdown structure and daily loss limit scope

### DIFF
--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -184,7 +184,7 @@ const planRules = [
     tagline: "Pass First, Activate Later",
     features: [
       "Evaluation Fee + $80 Activation Fee (after passing)",
-      "Static drawdown",
+      "Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown.",
       "50% consistency rule (evaluation only)",
       "5-day payout cycles",
       "Copy trading allowed",
@@ -198,7 +198,7 @@ const planRules = [
     tagline: "Instant Activation, No Activation Fee",
     features: [
       "You pay only the evaluation fee. No extra costs.",
-      "Static drawdown",
+      "Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown.",
       "No consistency rule",
       "Immediate activation",
       "5-day payout cycles",
@@ -217,7 +217,7 @@ const planRules = [
       "50% consistency rule (evaluation) / 40% consistency rule (funded)",
       "No activation fee",
       "5-day payout cycles",
-      "Static drawdown",
+      "Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown.",
       "Copy trading allowed",
       "One funded reset allowed per account",
     ],
@@ -562,7 +562,7 @@ const Rules = () => {
                       </div>
                       <div className="flex justify-between items-center py-2 border-b border-border/30">
                         <span className="text-sm text-muted-foreground">
-                          Daily Loss Limit
+                          Daily Loss Limit (Standard Plan Only)
                         </span>
                         <span className="font-semibold text-foreground">
                           {account.dailyLoss}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Plan Rules drawdown wording updated** — Replaced the generic "Static drawdown" bullet in the Standard, Advanced, and Builder plan feature lists with: _"Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown."_ This now matches the pricing page and accurately reflects the actual drawdown model used by Dynasty Futures.
- **Daily Loss Limit scoped to Standard Plan** — Updated the Account-Specific Rules table label from "Daily Loss Limit" to "Daily Loss Limit (Standard Plan Only)" so it's clear this limit does not apply to Advanced or Builder accounts.

No styling, layout, or unrelated text was changed.

## Test plan

- [ ] Visit `/rules` and open Plan Rules section — confirm all three plans show the updated drawdown wording
- [ ] Confirm the Account-Specific Rules cards display "Daily Loss Limit (Standard Plan Only)" with values intact
- [ ] Confirm no other text, layout, or styling changed on the page
- [ ] Confirm pricing page and FAQ are untouched

https://claude.ai/code/session_016Wo5Dugy5GDFykRyyUBedC
EOF
)