### PR TITLE
Mobile nav: match website menu to dashboard Sheet drawer style

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -1,7 +1,21 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { Menu, X, LogOut, User as UserIcon } from "lucide-react";
+import {
+  Menu,
+  LogOut,
+  User as UserIcon,
+  Home,
+  LayoutDashboard,
+  ShieldCheck,
+  Info,
+  Tag,
+  BookOpen,
+  HelpCircle,
+  Users,
+  MessageCircle,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import logo from "@/assets/Dynasty_Futures.png";
@@ -25,19 +39,17 @@ const Navbar = () => {
 
   // Build navigation links dynamically based on auth state
   const navLinks = [
-    { name: "Home", path: "/" },
-    // Only show Dashboard when logged in
-    ...(isAuthenticated ? [{ name: "Dashboard", path: "/dashboard" }] : []),
-    // Only show Admin when user is an admin
+    { name: "Home", path: "/", icon: Home },
+    ...(isAuthenticated ? [{ name: "Dashboard", path: "/dashboard", icon: LayoutDashboard }] : []),
     ...(isAuthenticated && user?.role === "ADMIN"
-      ? [{ name: "Admin", path: "/admin" }]
+      ? [{ name: "Admin", path: "/admin", icon: ShieldCheck }]
       : []),
-    { name: "About", path: "/about" },
-    { name: "Pricing", path: "/pricing" },
-    { name: "Rules", path: "/rules" },
-    { name: "FAQ", path: "/faq" },
-    { name: "Affiliates", path: "/affiliates" },
-    { name: "Support", path: "/support" },
+    { name: "About", path: "/about", icon: Info },
+    { name: "Pricing", path: "/pricing", icon: Tag },
+    { name: "Rules", path: "/rules", icon: BookOpen },
+    { name: "FAQ", path: "/faq", icon: HelpCircle },
+    { name: "Affiliates", path: "/affiliates", icon: Users },
+    { name: "Support", path: "/support", icon: MessageCircle },
   ];
 
   return (
@@ -90,10 +102,8 @@ const Navbar = () => {
           {/* Desktop CTA Buttons */}
           <div className="hidden md:flex items-center gap-3">
             {isLoading ? (
-              // Skeleton while session restores
               <div className="h-9 w-24 animate-pulse rounded-md bg-muted/30" />
             ) : isAuthenticated && user ? (
-              // Logged-in state
               <>
                 <div className="flex items-center gap-2 text-sm text-muted-foreground mr-1">
                   <UserIcon className="h-4 w-4" />
@@ -112,7 +122,6 @@ const Navbar = () => {
                 </Button>
               </>
             ) : (
-              // Logged-out state
               <>
                 <Button
                   variant="ghost"
@@ -135,84 +144,103 @@ const Navbar = () => {
             )}
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            onClick={() => setIsOpen(!isOpen)}
-            className="md:hidden p-2 text-foreground hover:text-primary transition-colors duration-300"
-          >
-            {isOpen ? <X size={24} /> : <Menu size={24} />}
-          </button>
-        </div>
-      </div>
-
-      {/* Mobile Menu */}
-      <div
-        className={cn(
-          "md:hidden absolute top-full left-0 right-0 glass border-b border-border/30 transition-all duration-300 overflow-hidden",
-          isOpen ? "max-h-[500px] opacity-100" : "max-h-0 opacity-0",
-        )}
-      >
-        <div className="container mx-auto px-4 py-4 flex flex-col gap-2">
-          {navLinks.map((link) => (
-            <Link
-              key={link.path}
-              to={link.path}
-              onClick={handleLinkClick}
-              className={cn(
-                "py-3 px-4 rounded-lg font-medium transition-all duration-300",
-                location.pathname === link.path ||
-                  location.pathname.startsWith(link.path + "/")
-                  ? "bg-primary/10 text-primary"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
-            >
-              {link.name}
-            </Link>
-          ))}
-          <div className="flex flex-col gap-2 pt-4 border-t border-border/50">
-            {isAuthenticated && user ? (
-              // Logged-in mobile
-              <>
-                <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground">
-                  <UserIcon className="h-4 w-4" />
-                  <span>
-                    {user.firstName} {user.lastName}
-                  </span>
-                  <span className="ml-auto text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
-                    {user.role}
-                  </span>
+          {/* Mobile Menu — Sheet drawer matching dashboard mobile nav */}
+          <div className="md:hidden">
+            <Sheet open={isOpen} onOpenChange={setIsOpen}>
+              <SheetTrigger asChild>
+                <button className="p-2 text-foreground hover:text-primary transition-colors duration-300">
+                  <Menu size={24} />
+                </button>
+              </SheetTrigger>
+              <SheetContent
+                side="left"
+                className="w-72 bg-card/95 backdrop-blur-xl border-border/30 p-0 flex flex-col gap-0"
+              >
+                {/* Drawer header with logo */}
+                <div className="p-6 border-b border-border/30">
+                  <img
+                    src={logo}
+                    alt="Dynasty Futures"
+                    className="h-10 w-auto logo-blend"
+                  />
                 </div>
-                <Button
-                  variant="outline"
-                  className="w-full border-border/50"
-                  onClick={handleLogout}
-                >
-                  <LogOut className="h-4 w-4 mr-2" />
-                  Logout
-                </Button>
-              </>
-            ) : (
-              // Logged-out mobile
-              <>
-                <Button
-                  variant="outline"
-                  className="w-full border-border/50"
-                  asChild
-                >
-                  <Link to="/login" onClick={handleLinkClick}>
-                    Trader Login
-                  </Link>
-                </Button>
-                <Button
-                  className="w-full btn-gradient-animated text-primary-foreground font-semibold"
-                  asChild
-                >
-                  <Link to="/pricing" onClick={handleLinkClick}>
-                    Start Challenge
-                  </Link>
-                </Button>
-              </>
-            )}
+
+                {/* Scrollable nav links */}
+                <div className="flex-1 overflow-y-auto min-h-0">
+                  <nav className="p-4 space-y-1">
+                    {navLinks.map((link) => {
+                      const Icon = link.icon;
+                      const active =
+                        location.pathname === link.path ||
+                        location.pathname.startsWith(link.path + "/");
+                      return (
+                        <Link
+                          key={link.path}
+                          to={link.path}
+                          onClick={handleLinkClick}
+                          className={cn(
+                            "flex items-center gap-3 px-4 py-3 rounded-xl font-medium text-sm transition-all duration-300",
+                            active
+                              ? "bg-primary/10 text-primary border border-primary/20"
+                              : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                          )}
+                        >
+                          <Icon
+                            size={20}
+                            className={active ? "text-primary" : ""}
+                          />
+                          <span>{link.name}</span>
+                        </Link>
+                      );
+                    })}
+                  </nav>
+                </div>
+
+                {/* Auth section pinned to bottom */}
+                <div className="p-4 border-t border-border/30 space-y-2">
+                  {isLoading ? (
+                    <div className="h-10 animate-pulse rounded-xl bg-muted/30" />
+                  ) : isAuthenticated && user ? (
+                    <>
+                      <div className="flex items-center gap-2 px-4 py-2 text-sm text-muted-foreground">
+                        <UserIcon className="h-4 w-4 shrink-0" />
+                        <span className="truncate">
+                          {user.firstName} {user.lastName}
+                        </span>
+                        <span className="ml-auto text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full shrink-0">
+                          {user.role}
+                        </span>
+                      </div>
+                      <button
+                        onClick={handleLogout}
+                        className="flex items-center gap-3 w-full px-4 py-3 rounded-xl font-medium text-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-all duration-300"
+                      >
+                        <LogOut size={20} />
+                        <span>Logout</span>
+                      </button>
+                    </>
+                  ) : (
+                    <>
+                      <Link
+                        to="/login"
+                        onClick={handleLinkClick}
+                        className="flex items-center justify-center gap-2 w-full px-4 py-3 rounded-xl font-medium text-sm border border-border/50 text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-all duration-300"
+                      >
+                        <UserIcon size={20} />
+                        <span>Trader Login</span>
+                      </Link>
+                      <Link
+                        to="/pricing"
+                        onClick={handleLinkClick}
+                        className="flex items-center justify-center w-full px-4 py-3 rounded-xl font-semibold text-sm btn-gradient-animated text-primary-foreground transition-all duration-300"
+                      >
+                        Start Challenge
+                      </Link>
+                    </>
+                  )}
+                </div>
+              </SheetContent>
+            </Sheet>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Replaces the old clipped `max-h-[500px]` dropdown** with a full-height left-side `Sheet` drawer — the same Radix UI component used by the dashboard mobile nav
- **Matches dashboard mobile menu exactly**: `bg-card/95 backdrop-blur-xl`, `w-72`, `rounded-xl` items, lucide icons per link, identical active/inactive states
- **Flex-column layout** keeps the auth section pinned at the bottom: logo header → scrollable nav links → auth footer, so all items (including "Start Challenge") are always reachable regardless of viewport height
- **Logout** is clearly visible and tappable at the bottom of the drawer when the user is logged in, with the same row style as the other nav items
- **Sheet overlay** (Radix dialog) handles z-index, backdrop dimming, focus-trap, click-outside-to-close, and the built-in X close button — no custom z-index hacks needed
- **Desktop nav, header, dropdowns, and dashboard layout are completely untouched** — this is a mobile-only change (gated by `md:hidden` on the trigger wrapper)

## Test plan

- [ ] Open site on a mobile viewport (< 768px) — hamburger icon visible in navbar
- [ ] Tap hamburger — left Sheet drawer slides in with logo, all nav links with icons
- [ ] All items visible and scrollable; "Start Challenge" button fully accessible
- [ ] Active page link highlighted with gold `bg-primary/10` border style
- [ ] Tapping any link closes the drawer and navigates correctly
- [ ] **Logged out**: "Trader Login" and "Start Challenge" appear at bottom of drawer
- [ ] **Logged in**: user name + role badge + "Logout" button appear at bottom; tapping Logout signs out and closes drawer
- [ ] Tapping outside the drawer or the X button closes it
- [ ] Desktop (≥ 768px) — no visual change to navbar, no Sheet visible

https://claude.ai/code/session_01E7tnxio2TUbFt6WBs6EKqX