### PR TITLE
Update Discord giveaway copy: 5 Standard 50K accounts

### DIFF
--- a/src/components/home/DiscordCTA.tsx
+++ b/src/components/home/DiscordCTA.tsx
@@ -16,8 +16,8 @@ const DiscordCTA = () => {
               </h2>
 
               <p className="text-lg text-muted-foreground mb-8 max-w-md">
-                We're giving away 3 50K accounts on launch day. The first 100
-                members to join the Discord are automatically entered to win.
+                We're giving away 5 Standard 50K accounts at launch. The first
+                100 members to join our Discord are automatically entered to win.
               </p>
 
               <Button


### PR DESCRIPTION
## Summary

- Updated Discord giveaway copy in `DiscordCTA.tsx` from "3 50K accounts" to "5 Standard 50K accounts"
- Replaced sentence with stronger, brand-consistent version: *"We're giving away 5 Standard 50K accounts at launch. The first 100 members to join our Discord are automatically entered to win."*
- No layout, styling, or structural changes — copy only

## Test plan

- [ ] Visit homepage and scroll to the Discord CTA section near the bottom
- [ ] Confirm giveaway text reads "5 Standard 50K accounts at launch"
- [ ] Confirm sentence flows naturally within the existing layout
- [ ] Confirm no other styling or layout changes are present

https://claude.ai/code/session_013X38DbREKfUroN2u6ErR31

---
_Generated by [Claude Code](https://claude.ai/code/session_013X38DbREKfUroN2u6ErR31)_