### PR TITLE
Add news trading restriction details to Rules and FAQ pages

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -68,6 +68,12 @@ const faqs = [
       "If you violate any of the trading rules (such as exceeding the daily loss limit, Max Loss Limit, holding over the weekend, or trading during high-impact news), your account may be flagged or terminated depending on the severity. Always review the rules carefully before trading.",
   },
   {
+    id: "news-trading",
+    question: "Is news trading allowed?",
+    answer:
+      "News trading is restricted during major scheduled economic events. Dynasty Futures prohibits opening new positions, increasing existing positions, or placing pending orders intended to trigger from 2 minutes before to 2 minutes after major releases, including CPI, PPI, Non-Farm Payrolls, and FOMC rate decisions. Traders are allowed to reduce or close existing positions during this time for risk management.",
+  },
+  {
     id: "real-money",
     question: "Do I trade real money during the challenge?",
     answer:

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -58,8 +58,9 @@ const universalRules = [
   {
     icon: Newspaper,
     title: "No News Trading",
+    label: "News Trading Restriction",
     description:
-      "Trading is not allowed during major high-impact news releases.",
+      "To protect traders and maintain fair market conditions, Dynasty Futures prohibits opening new positions, increasing existing positions, or placing pending orders intended to trigger during major scheduled news events. This restriction applies from 2 minutes before to 2 minutes after the release time of designated events, including CPI, PPI, Non-Farm Payrolls, and FOMC rate decisions. Traders may reduce or close existing positions during this window for risk management purposes.",
     allowed: false,
   },
   {
@@ -313,6 +314,9 @@ const UniversalRulesSection = () => {
         </button>
         {isExpanded && (
           <div className="px-3 pb-3 pl-12">
+            {"label" in rule && rule.label && (
+              <p className="text-sm font-semibold text-foreground mb-1">{rule.label}</p>
+            )}
             <p className="text-sm text-muted-foreground">{rule.description}</p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- **Rules page**: Expands the existing "No News Trading" rule with the full restriction details — 2-minute window before/after designated events (CPI, PPI, Non-Farm Payrolls, FOMC), with a "News Trading Restriction" subheading rendered above the description paragraph
- **FAQ page**: Adds a new "Is news trading allowed?" FAQ entry with consistent language, placed after the existing rule-violation FAQ

## Changes

- `src/pages/Rules.tsx` — Updates the `universalRules` "No News Trading" entry with a `label` field ("News Trading Restriction") and full description; updates `RuleRow` to optionally render the label as a bold subheading
- `src/pages/FAQ.tsx` — Adds `{ id: "news-trading", question: "Is news trading allowed?", answer: "..." }` after the rule-violation FAQ item

## Test plan

- [ ] Open `/rules` → expand Universal Rules → expand Restricted & Prohibited → click "No News Trading" → confirm "News Trading Restriction" subheading and full paragraph appear
- [ ] Open `/faq` → confirm "Is news trading allowed?" accordion item is present with correct answer
- [ ] Confirm no layout, styling, or other content was changed
- [ ] Confirm language is consistent between Rules and FAQ pages

https://claude.ai/code/session_01HAS7iVeKYpQqjDZ5auRnq9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAS7iVeKYpQqjDZ5auRnq9)_