### PR TITLE
fix(dashboard): trading accuracy, calendar hours, PnL colors, chart readability

### DIFF
--- a/src/components/dashboard/BuilderPanel.tsx
+++ b/src/components/dashboard/BuilderPanel.tsx
@@ -104,6 +104,7 @@ const BuilderPanel = ({
       isSelected: boolean;
       isToday: boolean;
       isCurrentMonth: boolean;
+      isSaturday: boolean;
     }> = [];
 
     const monthStart = startOfMonth(viewedMonth);
@@ -120,19 +121,22 @@ const BuilderPanel = ({
         isSelected: false,
         isToday: false,
         isCurrentMonth: false,
+        isSaturday: prevDate.getDay() === 6,
       });
     }
 
     for (let i = 0; i < daysInMonth; i++) {
       const date = new Date(monthStart);
       date.setDate(i + 1);
+      const dayOfWeek = date.getDay();
+      const isSaturday = dayOfWeek === 6;
 
       const daysFromToday = Math.floor(
         (today.getTime() - date.getTime()) / (1000 * 60 * 60 * 24),
       );
       const pnlIndex = account.dailyPnL.length - 1 - daysFromToday;
       const pnl =
-        pnlIndex >= 0 && pnlIndex < account.dailyPnL.length
+        !isSaturday && pnlIndex >= 0 && pnlIndex < account.dailyPnL.length
           ? account.dailyPnL[pnlIndex]
           : 0;
 
@@ -144,6 +148,7 @@ const BuilderPanel = ({
         isSelected: isSameDay(date, selectedDate),
         isToday: isSameDay(date, today),
         isCurrentMonth: true,
+        isSaturday,
       });
     }
 
@@ -304,20 +309,22 @@ const BuilderPanel = ({
                 <button
                   key={i}
                   onClick={() => {
-                    if (day.isCurrentMonth) {
+                    if (day.isCurrentMonth && !day.isSaturday) {
                       onDateChange(day.date);
                       navigate(
                         `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}`,
                       );
                     }
                   }}
-                  disabled={!day.isCurrentMonth}
+                  disabled={!day.isCurrentMonth || day.isSaturday}
                   className={cn(
                     "aspect-square rounded-md text-[10px] flex flex-col items-center justify-center transition-all duration-200",
-                    day.isCurrentMonth
+                    day.isCurrentMonth && !day.isSaturday
                       ? "hover:bg-muted/30 cursor-pointer"
-                      : "opacity-30 cursor-default",
-                    day.isSelected &&
+                      : day.isSaturday && day.isCurrentMonth
+                        ? "bg-muted/5 cursor-not-allowed"
+                        : "opacity-30 cursor-default",
+                    day.isSelected && !day.isSaturday &&
                       "ring-1 ring-primary bg-primary/20 shadow-[0_0_8px_hsl(var(--primary)/0.4)]",
                     day.isToday && !day.isSelected && "ring-1 ring-border",
                   )}
@@ -325,13 +332,14 @@ const BuilderPanel = ({
                   <span
                     className={cn(
                       "font-medium",
-                      day.isSelected && "text-primary",
+                      day.isSelected && !day.isSaturday && "text-primary",
                       !day.isCurrentMonth && "text-muted-foreground/50",
+                      day.isSaturday && day.isCurrentMonth && "text-muted-foreground/30",
                     )}
                   >
                     {day.dayNumber}
                   </span>
-                  {day.isCurrentMonth && !day.noTrades && (
+                  {day.isCurrentMonth && !day.noTrades && !day.isSaturday && (
                     <div
                       className={cn(
                         "w-1 h-1 rounded-full mt-0.5",
@@ -344,7 +352,7 @@ const BuilderPanel = ({
             </div>
 
             {/* Legend */}
-            <div className="flex items-center justify-center gap-4 mt-3 pt-2 border-t border-border/20">
+            <div className="flex items-center justify-center gap-3 mt-3 pt-2 border-t border-border/20">
               <div className="flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-primary" />
                 <span className="text-[9px] text-muted-foreground">Profit</span>
@@ -355,9 +363,11 @@ const BuilderPanel = ({
               </div>
               <div className="flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40" />
-                <span className="text-[9px] text-muted-foreground">
-                  No trades
-                </span>
+                <span className="text-[9px] text-muted-foreground">No trades</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-1.5 h-1.5 rounded-full bg-muted/50" />
+                <span className="text-[9px] text-muted-foreground">Closed</span>
               </div>
             </div>
           </div>

--- a/src/components/dashboard/DailyAnalytics.tsx
+++ b/src/components/dashboard/DailyAnalytics.tsx
@@ -78,7 +78,7 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
       <div className="p-3 rounded-xl bg-muted/10 border border-border/20 hover:border-primary/30 transition-all duration-300 group">
         <div className="flex items-center gap-2 mb-1.5">
           {dayPnL >= 0 ? (
-            <TrendingUp size={14} className="text-primary" />
+            <TrendingUp size={14} className="text-green-400" />
           ) : (
             <TrendingDown size={14} className="text-destructive" />
           )}
@@ -86,7 +86,7 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
         </div>
         <span className={cn(
           "text-lg font-bold",
-          dayPnL >= 0 ? "text-primary" : "text-destructive"
+          dayPnL >= 0 ? "text-green-400" : "text-destructive"
         )}>
           {formatCurrency(dayPnL, true)}
         </span>
@@ -140,7 +140,7 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
           <span className="text-xs text-muted-foreground">Best Trade</span>
         </div>
         <div className="flex items-baseline gap-1.5">
-          <span className="text-lg font-bold text-primary">+{formatCurrency(mockData.bestTrade)}</span>
+          <span className="text-lg font-bold text-green-400">+{formatCurrency(mockData.bestTrade)}</span>
           <span className="text-[10px] text-muted-foreground">({mockData.bestInstrument})</span>
         </div>
       </div>

--- a/src/components/dashboard/MetricCard.tsx
+++ b/src/components/dashboard/MetricCard.tsx
@@ -46,13 +46,18 @@ const MetricCard = ({
           </div>
         </div>
         <div className="flex items-end gap-2">
-          <span className="text-xl font-bold text-foreground">{value}</span>
+          <span className={cn(
+            "text-xl font-bold",
+            value.startsWith('+') ? "text-green-400" : "text-foreground",
+          )}>
+            {value}
+          </span>
           {trend && trendValue && (
             <span
               className={cn(
                 "text-xs font-semibold mb-0.5 flex items-center gap-0.5",
                 trend === "up"
-                  ? "text-primary"
+                  ? "text-green-400"
                   : trend === "down"
                     ? "text-destructive"
                     : "text-muted-foreground",

--- a/src/components/dashboard/PerformanceChart.tsx
+++ b/src/components/dashboard/PerformanceChart.tsx
@@ -200,17 +200,17 @@ const PerformanceChart = ({
               <XAxis
                 dataKey="date"
                 stroke="hsl(var(--muted-foreground))"
-                fontSize={11}
+                fontSize={9}
                 tickLine={false}
                 axisLine={false}
                 interval="preserveStartEnd"
               />
               <YAxis
                 stroke="hsl(var(--muted-foreground))"
-                fontSize={11}
+                fontSize={9}
                 tickLine={false}
                 axisLine={false}
-                tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`}
+                tickFormatter={(value) => `$${(value / 1000).toFixed(1)}k`}
                 domain={[minBalance - padding, maxBalance + padding]}
               />
               <Tooltip content={<CustomTooltip />} />
@@ -258,18 +258,18 @@ const PerformanceChart = ({
               <XAxis
                 dataKey="date"
                 stroke="hsl(var(--muted-foreground))"
-                fontSize={11}
+                fontSize={9}
                 tickLine={false}
                 axisLine={false}
                 interval="preserveStartEnd"
               />
               <YAxis
                 stroke="hsl(var(--muted-foreground))"
-                fontSize={11}
+                fontSize={9}
                 tickLine={false}
                 axisLine={false}
                 tickFormatter={(value) =>
-                  `${value >= 0 ? "+" : ""}$${value.toLocaleString()}`
+                  `${value >= 0 ? "+" : "-"}$${(Math.abs(value) / 1000).toFixed(1)}k`
                 }
                 domain={[minPnL - pnlPadding, maxPnL + pnlPadding]}
               />

--- a/src/components/dashboard/SummaryPanel.tsx
+++ b/src/components/dashboard/SummaryPanel.tsx
@@ -116,6 +116,7 @@ const SummaryPanel = ({
       isSelected: boolean;
       isToday: boolean;
       isCurrentMonth: boolean;
+      isSaturday: boolean;
     }> = [];
 
     // Get the first day of the viewed month
@@ -134,6 +135,7 @@ const SummaryPanel = ({
         isSelected: false,
         isToday: false,
         isCurrentMonth: false,
+        isSaturday: prevDate.getDay() === 6,
       });
     }
 
@@ -141,6 +143,8 @@ const SummaryPanel = ({
     for (let i = 0; i < daysInMonth; i++) {
       const date = new Date(monthStart);
       date.setDate(i + 1);
+      const dayOfWeek = date.getDay();
+      const isSaturday = dayOfWeek === 6;
 
       // Get P&L for this day from dailyPnL array (index from end)
       const daysFromToday = Math.floor(
@@ -148,7 +152,7 @@ const SummaryPanel = ({
       );
       const pnlIndex = account.dailyPnL.length - 1 - daysFromToday;
       const pnl =
-        pnlIndex >= 0 && pnlIndex < account.dailyPnL.length
+        !isSaturday && pnlIndex >= 0 && pnlIndex < account.dailyPnL.length
           ? account.dailyPnL[pnlIndex]
           : 0;
 
@@ -160,6 +164,7 @@ const SummaryPanel = ({
         isSelected: isSameDay(date, selectedDate),
         isToday: isSameDay(date, today),
         isCurrentMonth: true,
+        isSaturday,
       });
     }
 
@@ -216,7 +221,7 @@ const SummaryPanel = ({
           <span className="text-[10px] text-muted-foreground uppercase tracking-wider font-medium">
             Funding Requirements
           </span>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 mt-2">
+          <div className={cn("grid grid-cols-1 gap-2 mt-2", account.planType === 'Standard' ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
             <SummaryItem
               label="Profit Target"
               value={formatCurrency(account.profitTarget)}
@@ -231,12 +236,14 @@ const SummaryPanel = ({
               variant="danger"
             />
 
-            <SummaryItem
-              label="Daily Loss Limit"
-              value={formatCurrency(account.dailyLossLimit)}
-              icon={<TrendingDown size={14} className="text-yellow-500" />}
-              variant="warning"
-            />
+            {account.planType === 'Standard' && (
+              <SummaryItem
+                label="Daily Loss Limit"
+                value={formatCurrency(account.dailyLossLimit)}
+                icon={<TrendingDown size={14} className="text-yellow-500" />}
+                variant="warning"
+              />
+            )}
           </div>
         </div>
 
@@ -319,22 +326,24 @@ const SummaryPanel = ({
                 <button
                   key={i}
                   onClick={() => {
-                    if (day.isCurrentMonth) {
+                    if (day.isCurrentMonth && !day.isSaturday) {
                       onDateChange(day.date);
                       navigate(
                         `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}`,
                       );
                     }
                   }}
-                  disabled={!day.isCurrentMonth}
+                  disabled={!day.isCurrentMonth || day.isSaturday}
                   className={cn(
                     "aspect-square rounded-md text-[10px] flex flex-col items-center justify-center transition-all duration-200",
                     // Base styles
-                    day.isCurrentMonth
+                    day.isCurrentMonth && !day.isSaturday
                       ? "hover:bg-muted/30 cursor-pointer"
-                      : "opacity-30 cursor-default",
+                      : day.isSaturday && day.isCurrentMonth
+                        ? "bg-muted/5 cursor-not-allowed"
+                        : "opacity-30 cursor-default",
                     // Selected day - highlight glow
-                    day.isSelected &&
+                    day.isSelected && !day.isSaturday &&
                       "ring-1 ring-primary bg-primary/20 shadow-[0_0_8px_hsl(var(--primary)/0.4)]",
                     // Today marker (if not selected)
                     day.isToday && !day.isSelected && "ring-1 ring-border",
@@ -343,14 +352,15 @@ const SummaryPanel = ({
                   <span
                     className={cn(
                       "font-medium",
-                      day.isSelected && "text-primary",
+                      day.isSelected && !day.isSaturday && "text-primary",
                       !day.isCurrentMonth && "text-muted-foreground/50",
+                      day.isSaturday && day.isCurrentMonth && "text-muted-foreground/30",
                     )}
                   >
                     {day.dayNumber}
                   </span>
-                  {/* P&L indicator dot */}
-                  {day.isCurrentMonth && !day.noTrades && (
+                  {/* P&L indicator dot - never shown on Saturday */}
+                  {day.isCurrentMonth && !day.noTrades && !day.isSaturday && (
                     <div
                       className={cn(
                         "w-1 h-1 rounded-full mt-0.5",
@@ -363,7 +373,7 @@ const SummaryPanel = ({
             </div>
 
             {/* Legend */}
-            <div className="flex items-center justify-center gap-4 mt-3 pt-2 border-t border-border/20">
+            <div className="flex items-center justify-center gap-3 mt-3 pt-2 border-t border-border/20">
               <div className="flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-primary" />
                 <span className="text-[9px] text-muted-foreground">Profit</span>
@@ -374,9 +384,11 @@ const SummaryPanel = ({
               </div>
               <div className="flex items-center gap-1.5">
                 <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40" />
-                <span className="text-[9px] text-muted-foreground">
-                  No trades
-                </span>
+                <span className="text-[9px] text-muted-foreground">No trades</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-1.5 h-1.5 rounded-full bg-muted/50" />
+                <span className="text-[9px] text-muted-foreground">Closed</span>
               </div>
             </div>
           </div>

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -260,9 +260,9 @@ export const generateChartData = (
   timeframe: string
 ): ChartDataPoint[] => {
   const today = new Date();
-  const days = timeframe === '1' ? 24 : timeframe === '7' ? 7 : timeframe === '90' ? 90 : 30;
-  
-  if (timeframe === '1') {
+  const days = timeframe === 'daily' ? 1 : timeframe === 'weekly' ? 7 : 30;
+
+  if (timeframe === 'daily') {
     // Intraday - show hourly data
     const data: ChartDataPoint[] = [];
     const baseBalance = account.currentBalance;

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -42,7 +42,7 @@ const DashboardHome = () => {
     }
   }, [searchParams, setSearchParams]);
   const [selectedAccount, setSelectedAccount] = useState("2"); // Default to 50K Advanced
-  const [dateRange, setDateRange] = useState("30");
+  const [dateRange, setDateRange] = useState("monthly");
   const [chartType, setChartType] = useState<"equity" | "pnl">("equity");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date()); // For Daily Performance Calendar
 
@@ -91,26 +91,26 @@ const DashboardHome = () => {
               <Button
                 variant="ghost"
                 size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "7" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("7")}
+                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "daily" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+                onClick={() => setDateRange("daily")}
               >
-                7 Days
+                Daily
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "30" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("30")}
+                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "weekly" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+                onClick={() => setDateRange("weekly")}
               >
-                30 Days
+                Weekly
               </Button>
               <Button
                 variant="ghost"
                 size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "90" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("90")}
+                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "monthly" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
+                onClick={() => setDateRange("monthly")}
               >
-                90 Days
+                Monthly
               </Button>
             </div>
             <AccountSelector


### PR DESCRIPTION
## Summary

- **Calendar — Futures market hours**: Saturday is now non-tradable (grayed out, disabled, no P&L dots). Matches real futures schedule: open Sun evening through Fri, closed Saturday. "Closed" key added to calendar legend in both SummaryPanel and BuilderPanel.
- **Positive PnL → green**: Account balance trendValue, Closed P&L value, Daily P&L, and Best Trade now display in green when positive (with `+` sign). Negative values unchanged. Dynasty gold/amber branding preserved for all other elements.
- **Account switching accuracy**: Daily Loss Limit is now hidden for Advanced and Builder plans in SummaryPanel — shown only for Standard plan. Grid adjusts to 2 columns when the field is absent.
- **Timeframe options**: Replaced 7 Days / 30 Days / 90 Days with Daily / Weekly / Monthly. `generateChartData` updated to map the new string keys (`daily` → intraday, `weekly` → 7 days, `monthly` → 30 days). Default view is Monthly.
- **Chart readability**: Axis font size reduced from 11 → 9. P&L chart Y-axis now uses abbreviated `$Xk` format (matching the equity chart), making dense tick labels easier to scan.

## Files changed

| File | Change |
|---|---|
| `src/data/mockDashboardData.ts` | New timeframe key parsing (`daily`/`weekly`/`monthly`) |
| `src/pages/dashboard/DashboardHome.tsx` | Timeframe button labels/values, default state |
| `src/components/dashboard/MetricCard.tsx` | Green color for `+` values and `trend="up"` |
| `src/components/dashboard/DailyAnalytics.tsx` | Green for Day's P&L and Best Trade |
| `src/components/dashboard/SummaryPanel.tsx` | Calendar Saturday fix, conditional Daily Loss Limit |
| `src/components/dashboard/BuilderPanel.tsx` | Calendar Saturday fix |
| `src/components/dashboard/PerformanceChart.tsx` | Smaller axis font, abbreviated P&L Y-axis |

## Test plan

- [ ] Switch between Standard / Advanced / Builder accounts — verify Daily Loss Limit only appears for Standard
- [ ] Check calendar in both SummaryPanel and BuilderPanel — all Saturday cells should be grayed, non-clickable, and show no P&L dots
- [ ] Verify positive Account Balance trendValue and Closed P&L value display in green
- [ ] Toggle Daily / Weekly / Monthly timeframes — chart data and reference lines update per account
- [ ] Switch accounts while in Monthly view — profit target and max loss reference lines match selected account
- [ ] P&L chart Y-axis displays abbreviated `+$Xk` / `-$Xk` format

https://claude.ai/code/session_01RkeCQgvBh9YJiYw4DQymNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkeCQgvBh9YJiYw4DQymNj)_