### PR TITLE
Fix dashboard: green positive values in Trading Analytics + daily chart accuracy

### DIFF
--- a/src/components/dashboard/AccountMetrics.tsx
+++ b/src/components/dashboard/AccountMetrics.tsx
@@ -141,7 +141,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
               <TrendingUp size={14} className="text-primary" />
               <span className="text-xs text-muted-foreground">Avg. Win</span>
             </div>
-            <span className="text-lg font-bold text-primary">
+            <span className="text-lg font-bold text-green-400">
               {formatCurrency(metrics.avgWin, true)}
             </span>
           </div>
@@ -239,7 +239,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
             </div>
             <div className="flex flex-col items-center justify-center">
               <span
-                className={`text-2xl font-bold ${expectancy > 0 ? "text-primary" : "text-destructive"}`}
+                className={`text-2xl font-bold ${expectancy > 0 ? "text-green-400" : "text-destructive"}`}
               >
                 {formatCurrency(Math.round(expectancy), true)}
               </span>
@@ -326,7 +326,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                             {data.time}
                           </p>
                           <p
-                            className={`text-sm font-bold ${data.value >= 0 ? "text-primary" : "text-destructive"}`}
+                            className={`text-sm font-bold ${data.value >= 0 ? "text-green-400" : "text-destructive"}`}
                           >
                             {formatCurrency(data.value, true)}
                           </p>
@@ -348,7 +348,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
             <span className="text-[10px] font-medium text-primary">
               {bestSession.name}
             </span>
-            <span className="text-[10px] text-primary">
+            <span className="text-[10px] text-green-400">
               {formatCurrency(bestSession.value, true)}
             </span>
           </div>
@@ -502,7 +502,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                 </span>
               </div>
               <span
-                className={`text-sm font-bold ${totalPnl >= 0 ? "text-primary" : "text-destructive"}`}
+                className={`text-sm font-bold ${totalPnl >= 0 ? "text-green-400" : "text-destructive"}`}
               >
                 {formatCurrency(totalPnl, true)}
               </span>
@@ -529,7 +529,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                   </div>
                   <div className="text-right">
                     <span
-                      className={`text-sm font-bold ${inst.pnl >= 0 ? "text-primary" : "text-destructive"}`}
+                      className={`text-sm font-bold ${inst.pnl >= 0 ? "text-green-400" : "text-destructive"}`}
                     >
                       {formatCurrency(inst.pnl, true)}
                     </span>

--- a/src/components/dashboard/PerformanceChart.tsx
+++ b/src/components/dashboard/PerformanceChart.tsx
@@ -22,6 +22,7 @@ interface PerformanceChartProps {
   chartType: "equity" | "pnl";
   onChartTypeChange: (type: "equity" | "pnl") => void;
   startingBalance: number;
+  timeframe?: string;
   className?: string;
 }
 
@@ -84,13 +85,20 @@ const PerformanceChart = ({
   chartType,
   onChartTypeChange,
   startingBalance,
+  timeframe,
   className,
 }: PerformanceChartProps) => {
-  // Calculate Y-axis domain
+  const isDailyView = timeframe === 'daily';
+
+  // Calculate Y-axis domain — for daily view use only balance data so intraday movement is visible
   const allBalances = data.map((d) => d.balance);
-  const minBalance = Math.min(...allBalances, data[0]?.maxLoss || 0);
-  const maxBalance = Math.max(...allBalances, data[0]?.profitTarget || 0);
-  const padding = (maxBalance - minBalance) * 0.1;
+  const minBalance = isDailyView
+    ? Math.min(...allBalances)
+    : Math.min(...allBalances, data[0]?.maxLoss || 0);
+  const maxBalance = isDailyView
+    ? Math.max(...allBalances)
+    : Math.max(...allBalances, data[0]?.profitTarget || 0);
+  const padding = Math.max((maxBalance - minBalance) * 0.15, isDailyView ? 30 : 0);
 
   // Calculate P&L domain
   const allPnL = data.map((d) => d.pnl);

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -257,36 +257,52 @@ export interface ChartDataPoint {
 // Generate chart data with real dates
 export const generateChartData = (
   account: AccountData,
-  timeframe: string
+  timeframe: string,
+  selectedDate?: Date
 ): ChartDataPoint[] => {
   const today = new Date();
-  const days = timeframe === 'daily' ? 1 : timeframe === 'weekly' ? 7 : 30;
 
   if (timeframe === 'daily') {
-    // Intraday - show hourly data
+    const targetDate = selectedDate ?? today;
+    const daysAgo = Math.floor((today.getTime() - targetDate.getTime()) / (1000 * 60 * 60 * 24));
+    const pnlIndex = account.dailyPnL.length - 1 - daysAgo;
+
+    let dayPnL = 0;
+    let dayEndBalance = account.currentBalance;
+
+    if (pnlIndex >= 0 && pnlIndex < account.dailyPnL.length) {
+      dayPnL = account.dailyPnL[pnlIndex];
+      dayEndBalance = account.equityHistory[pnlIndex] ?? account.currentBalance;
+    }
+
+    const dayStartBalance = dayEndBalance - dayPnL;
     const data: ChartDataPoint[] = [];
-    const baseBalance = account.currentBalance;
-    const hourlyVariation = account.dailyPnL[account.dailyPnL.length - 1] / 8;
-    
+
     for (let i = 0; i < 8; i++) {
-      const hour = setHours(today, 9 + i);
-      const variation = (Math.random() - 0.4) * Math.abs(hourlyVariation) * 2;
+      const hour = setHours(targetDate, 9 + i);
+      const progress = (i + 1) / 8;
+      // Deterministic noise seeded by account size, day index, and hour
+      const noiseMag = Math.max(Math.abs(dayPnL) * 0.04, 5);
+      const noise = Math.sin(account.size + pnlIndex * 7 + i * 13) * noiseMag;
+      const balance = Math.round(dayStartBalance + dayPnL * progress + noise);
+
       data.push({
         date: format(hour, 'ha'),
-        balance: Math.round(baseBalance - (8 - i) * hourlyVariation + variation),
+        balance,
         maxLoss: account.startingBalance - account.maxDrawdown,
         profitTarget: account.startingBalance + account.profitTarget,
-        pnl: Math.round(variation),
+        pnl: Math.round(dayPnL / 8 + noise),
       });
     }
     return data;
   }
-  
+
   // Multi-day timeframes
+  const days = timeframe === 'weekly' ? 7 : 30;
   const sliceStart = Math.max(0, account.equityHistory.length - days);
   const equitySlice = account.equityHistory.slice(sliceStart);
   const pnlSlice = account.dailyPnL.slice(sliceStart);
-  
+
   return equitySlice.map((balance, index) => {
     const date = subDays(today, days - 1 - index);
     return {

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -54,10 +54,10 @@ const DashboardHome = () => {
   // Determine if this is a Builder account
   const isBuilderAccount = accountData.planType === "Builder";
 
-  // Generate chart data based on selected account and timeframe
+  // Generate chart data based on selected account, timeframe, and selected date (daily view uses selected date)
   const chartData = useMemo(() => {
-    return generateChartData(accountData, dateRange);
-  }, [accountData, dateRange]);
+    return generateChartData(accountData, dateRange, dateRange === 'daily' ? selectedDate : undefined);
+  }, [accountData, dateRange, selectedDate]);
 
   // Format currency values
   const formatCurrency = (value: number, showSign = false) => {
@@ -164,6 +164,7 @@ const DashboardHome = () => {
           chartType={chartType}
           onChartTypeChange={setChartType}
           startingBalance={accountData.startingBalance}
+          timeframe={dateRange}
           className="h-[calc(100vh-380px)] min-h-[400px]"
         />
       </ScrollReveal>


### PR DESCRIPTION
## Summary

- **Trading Analytics green values** — `AccountMetrics` now renders all positive profit/PnL figures (`avgWin`, `expectancy`, session tooltip P&L, best session value, instrument P&L, total P&L contribution) in `text-green-400` instead of `text-primary` (gold). Neutral labels, icons, ratios (profit factor, R:R), and win-rate percentages are unchanged.
- **Calendar date click PnL color** — `DailyAnalytics` already colors positive PnL green; the chart data now also updates when a calendar date is selected in Daily mode, so the full row of metrics and the chart reflect the clicked date's actual P&L.
- **Daily chart accuracy** — Rewrote `generateChartData` daily-view logic: balance now paths from `dayStartBalance` (= end-of-day balance minus that day's PnL) to `dayEndBalance` using the selected date's actual PnL. Noise is deterministic (seeded by account/day) to prevent flicker. `PerformanceChart` receives a new `timeframe` prop and excludes the full-account reference-line bounds from the Y-axis domain when in daily view, so intraday movement is clearly visible instead of appearing flat.

## Test plan

- [ ] Switch chart to **Daily** view — confirm line slopes upward on a positive PnL day and downward on a negative day (not flat)
- [ ] Click different calendar dates while in Daily view — confirm chart and DailyAnalytics update to that date's data
- [ ] Confirm positive PnL values in Trading Analytics (Avg. Win, Expectancy, session tooltip, instrument P&L) display in green
- [ ] Confirm negative values remain red and neutral labels/icons remain gold
- [ ] Switch to Weekly and Monthly views — confirm reference lines and chart behavior are unchanged
- [ ] Switch accounts — confirm Daily chart reflects the selected account's data

https://claude.ai/code/session_01CzwCnnf4rAfBPxGJS7Xj5g

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzwCnnf4rAfBPxGJS7Xj5g)_