### PR TITLE
Update Twitter footer link to official Dynasty Futures account

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -63,7 +63,7 @@ const Footer = () => {
                   </svg>
                 </a>
                 <a
-                  href="https://x.com/dynastyfutures"
+                  href="https://twitter.com/DynastyFuturesT"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="X (Twitter)"


### PR DESCRIPTION
## Summary

- Updated the Twitter (X) icon link in the footer from `https://x.com/dynastyfutures` to `https://twitter.com/DynastyFuturesT`

## Test plan

- [ ] Verify the Twitter icon in the footer links to https://twitter.com/DynastyFuturesT
- [ ] Confirm the link opens in a new tab
- [ ] Confirm no other footer links, layout, or styling were affected

https://claude.ai/code/session_01LpU3oBAmeKLcwNMA4cZqAf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpU3oBAmeKLcwNMA4cZqAf)_