### PR TITLE
feat(about): add Technical/Software section with Justin Perez and William Kelly

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -468,6 +468,65 @@ const About = () => {
             </div>
           </div>
 
+          {/* Technical / Software */}
+          <div className="mb-20 md:mb-28">
+            <ScrollReveal>
+              <div className="text-center mb-12">
+                <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground mb-3">
+                  Technical /{" "}
+                  <span className="text-gradient-animated">Software</span>
+                </h2>
+                <div className="w-20 h-px bg-primary/30 mx-auto my-3" />
+                <p className="text-muted-foreground">Principals</p>
+              </div>
+            </ScrollReveal>
+
+            <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+              <ScrollReveal delay={0}>
+                <div className="bg-gradient-card rounded-2xl border border-border/50 p-8 h-full">
+                  <div className="mb-6">
+                    <h3 className="font-display text-xl font-bold text-foreground mb-1">
+                      Justin Perez
+                    </h3>
+                    <p className="text-primary text-sm font-medium">
+                      Co-Lead Developer
+                    </p>
+                  </div>
+                  <a
+                    href="https://linkedin.com/in/justindperez"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
+                  >
+                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
+                    <span>Connect on LinkedIn</span>
+                  </a>
+                </div>
+              </ScrollReveal>
+
+              <ScrollReveal delay={100}>
+                <div className="bg-gradient-card rounded-2xl border border-border/50 p-8 h-full">
+                  <div className="mb-6">
+                    <h3 className="font-display text-xl font-bold text-foreground mb-1">
+                      William Kelly
+                    </h3>
+                    <p className="text-primary text-sm font-medium">
+                      Co-Lead Developer
+                    </p>
+                  </div>
+                </div>
+              </ScrollReveal>
+            </div>
+
+            <ScrollReveal>
+              <p className="text-center text-muted-foreground mt-8 max-w-2xl mx-auto">
+                Justin &amp; William are the engine of Dynasty Futures and are responsible for all aspects of software development, platform integration, and technical oversight.
+              </p>
+            </ScrollReveal>
+          </div>
+
           {/* Join the Dynasty CTA */}
           <ScrollReveal>
             <div className="text-center max-w-2xl mx-auto">


### PR DESCRIPTION
## Summary

- Adds a new **Technical / Software — Principals** section to the About page, directly below the Founders & Leadership section
- Includes side-by-side cards for **Justin Perez** (Co-Lead Developer) and **William Kelly** (Co-Lead Developer) using the exact same `bg-gradient-card` card styling, typography, and spacing as the existing founder cards
- Adds a LinkedIn link for Justin Perez (`https://linkedin.com/in/justindperez`) using the identical SVG icon, `inline-flex items-center gap-2` class structure, and hover behavior as all founder LinkedIn links
- Section header uses the same `font-display` h2 styling with `text-gradient-animated` span, a thin `bg-primary/30` divider line, and a centered "Principals" subheading
- Adds centered `text-muted-foreground` description below both cards: "Justin & William are the engine of Dynasty Futures..."
- No existing sections, styles, or layout altered — purely additive change (59 lines inserted)

## Test plan

- [ ] Visit `/about` and confirm the Technical / Software section appears directly below the Founders section
- [ ] Verify card styling (background, border, rounded corners, typography) matches the Zachary Perez / Cliff Adams cards exactly
- [ ] Confirm Justin Perez's LinkedIn link is clickable, opens `https://linkedin.com/in/justindperez` in a new tab, and icon/text style matches founder links
- [ ] Verify the thin gold divider line and "Principals" subheading render correctly under the section title
- [ ] Confirm the description paragraph is centered and uses `text-muted-foreground`
- [ ] Check mobile layout — cards should stack vertically on small screens (existing `md:grid-cols-2` pattern)
- [ ] Verify no visual regressions in sections above or below (Founders, CTA)

https://claude.ai/code/session_015jQPSnmYPUwpDU2ed2CD8r

---
_Generated by [Claude Code](https://claude.ai/code/session_015jQPSnmYPUwpDU2ed2CD8r)_