### PR TITLE
Fix affiliate tier requirements: Growth Affiliate 12%, Dynasty Partner at 30 sales/$7,500

### DIFF
--- a/src/pages/dashboard/DashboardAffiliate.tsx
+++ b/src/pages/dashboard/DashboardAffiliate.tsx
@@ -55,8 +55,8 @@ const TIER_CONFIG: Record<AffiliateTier, TierConfig> = {
     accentClass: "bg-gold-dark/10",
     borderClass: "border-gold-dark/30",
     nextTier: "Dynasty Partner",
-    nextSalesGoal: 50,
-    nextRevenueGoal: 10000,
+    nextSalesGoal: 30,
+    nextRevenueGoal: 7500,
   },
   "Dynasty Partner": {
     commission: 15,
@@ -307,7 +307,7 @@ const DashboardAffiliate = () => {
                           "en-US",
                           { maximumFractionDigits: 0 }
                         )}{" "}
-                        / $10,000
+                        / $7,500
                       </p>
                     </div>
                     <div className="w-full bg-background/40 rounded-full h-2 border border-border/20">


### PR DESCRIPTION
## Summary

- Updates `TIER_CONFIG` for Growth Affiliate: `nextSalesGoal` 50 → 30 and `nextRevenueGoal` 10000 → 7500
- Fixes the hardcoded `$10,000` display string in the revenue progress bar to `$7,500`
- Growth Affiliate commission was already correct at 12%; no change needed there
- Public `Affiliates.tsx` page was already correct; only `DashboardAffiliate.tsx` required updates

## Tier structure now reflected in dashboard

| Tier | Commission | Unlock requirement |
|---|---|---|
| Community Affiliate | 10% | Entry level |
| Growth Affiliate | 12% | 15 qualified sales (rolling 90 days) |
| Dynasty Partner | 15% | 30 qualified sales OR $7,500 revenue (rolling 90 days) + clean compliance |

## Test plan

- [ ] Visit `/dashboard/affiliate` and confirm Tier Progress shows correct next-tier goals (30 sales / $7,500) for a Growth Affiliate user
- [ ] Confirm revenue progress bar label reads `/ $7,500`
- [ ] Confirm commission rates display as 10% / 12% / 15% per tier
- [ ] Confirm referral link and copy/code buttons still function normally
- [ ] Confirm no layout or styling regressions

https://claude.ai/code/session_01Cvr8XZUU6mqzbHumprM1YM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cvr8XZUU6mqzbHumprM1YM)_