### PR TITLE
Add affiliate payout details to public and dashboard affiliate pages

### DIFF
--- a/src/pages/Affiliates.tsx
+++ b/src/pages/Affiliates.tsx
@@ -23,6 +23,7 @@ import {
   CheckCircle,
   Zap,
   BarChart2,
+  Clock,
 } from "lucide-react";
 
 const tradeFirstCards = [
@@ -475,6 +476,57 @@ const Affiliates = () => {
               </div>
             </ScrollReveal>
           </div>
+
+          {/* ─── Affiliate Payout Details ─────────────────────────────── */}
+          <ScrollReveal>
+            <div className="mb-20 md:mb-28 max-w-4xl mx-auto">
+              <div className="text-center mb-8">
+                <h2 className="font-display text-2xl md:text-3xl font-bold text-foreground mb-3">
+                  Affiliate Payout{" "}
+                  <span className="text-gradient-animated">Details</span>
+                </h2>
+              </div>
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="bg-gradient-card rounded-2xl border border-border/50 p-6 hover:border-primary/30 transition-all duration-300">
+                  <div className="flex items-start gap-4">
+                    <div className="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center flex-shrink-0 mt-1">
+                      <DollarSign className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <h3 className="font-display font-semibold text-foreground mb-2">
+                        Minimum Payout Threshold
+                      </h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        A minimum balance of{" "}
+                        <span className="text-primary font-semibold">$1,000</span>{" "}
+                        is required before a payout is issued.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div className="bg-gradient-card rounded-2xl border border-border/50 p-6 hover:border-primary/30 transition-all duration-300">
+                  <div className="flex items-start gap-4">
+                    <div className="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center flex-shrink-0 mt-1">
+                      <Clock className="w-5 h-5 text-primary" />
+                    </div>
+                    <div>
+                      <h3 className="font-display font-semibold text-foreground mb-2">
+                        Monthly Payout Cycle
+                      </h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        Commissions are paid monthly. Earnings from the prior
+                        month are issued by the{" "}
+                        <span className="text-primary font-semibold">
+                          15th of the following month
+                        </span>
+                        .
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ScrollReveal>
 
           {/* ─── Founding Affiliate Perk ──────────────────────────────── */}
           <ScrollReveal>

--- a/src/pages/dashboard/DashboardAffiliate.tsx
+++ b/src/pages/dashboard/DashboardAffiliate.tsx
@@ -574,6 +574,44 @@ const DashboardAffiliate = () => {
           </div>
         </div>
 
+        {/* Affiliate Payout Details */}
+        <div>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-1 h-6 bg-primary rounded-full"></div>
+            <h2 className="text-lg font-semibold text-foreground">
+              Affiliate Payout Details
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-5 transition-all duration-300 hover:border-primary/30 hover:translate-y-[-2px]">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+                  <CircleDollarSign size={20} className="text-primary" />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground mb-1">
+                Minimum Payout Threshold
+              </p>
+              <p className="text-2xl font-bold text-primary">$1,000</p>
+              <p className="text-xs text-muted-foreground mt-2 leading-relaxed">
+                Required balance before a payout is issued
+              </p>
+            </div>
+            <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-5 transition-all duration-300 hover:border-gold-dark/30 hover:translate-y-[-2px]">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-10 h-10 rounded-xl bg-gold-dark/10 flex items-center justify-center">
+                  <Clock size={20} className="text-gold-dark" />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground mb-1">Payout Cycle</p>
+              <p className="text-2xl font-bold text-gold-dark">Monthly</p>
+              <p className="text-xs text-muted-foreground mt-2 leading-relaxed">
+                Prior month commissions paid by the 15th of the following month
+              </p>
+            </div>
+          </div>
+        </div>
+
         {/* Performance Metrics */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <div className="rounded-xl bg-card/30 backdrop-blur-sm border border-border/20 p-4 transition-all duration-300 hover:border-primary/20 hover:translate-y-[-2px]">


### PR DESCRIPTION
## Summary

- Adds a new **"Affiliate Payout Details"** section to the public affiliate page (`/affiliates`), placed between the Tiered Affiliate Structure and the Founding Affiliate Perk sections
- Adds a new **"Affiliate Payout Details"** section to the dashboard affiliate page (`/dashboard/affiliate`), placed after the Earnings Overview and before Performance Metrics
- Both sections clearly state:
  - **$1,000 minimum payout threshold** — required balance before a payout is issued
  - **Monthly payout cycle** — prior month commissions paid by the 15th of the following month

## What was not changed

- Affiliate tier requirements and commission rates
- Referral link and discount code functionality
- Affiliate application flow
- Dashboard sidebar
- Existing support/contact sections
- Page layout, branding, fonts, colors, or spacing

## Test plan

- [ ] Visit `/affiliates` and confirm the "Affiliate Payout Details" section appears between the tier structure cards and the Founding Affiliate Perk banner
- [ ] Visit `/dashboard/affiliate` and confirm the "Affiliate Payout Details" section appears after the Earnings Overview cards
- [ ] Verify both sections show $1,000 minimum threshold and monthly / 15th payout cycle copy
- [ ] Confirm no existing sections were moved, restyled, or removed

https://claude.ai/code/session_01CVeodHRMkbsUPawsCUxu2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVeodHRMkbsUPawsCUxu2Q)_