### PR TITLE
feat(auth): handle session invalidation and cross-tab sync

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -20,9 +20,10 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { toast } from 'sonner';
 import type { User, UserRole } from '@/types/user';
 import { authApi } from '@/services/auth';
-import { setTokenAccessor } from '@/services/api';
+import { setTokenAccessor, setUnauthorizedHandler } from '@/services/api';
 import { ApiError } from '@/types/api';
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,13 @@ import { ApiError } from '@/types/api';
 // ---------------------------------------------------------------------------
 
 const REFRESH_TOKEN_KEY = 'df_refresh_token';
+const AUTH_CHANNEL_NAME = 'df-auth';
+
+// Cross-tab sync message shapes. `BroadcastChannel` only delivers to OTHER
+// tabs, so a tab never receives its own posts.
+type AuthBroadcastMessage =
+  | { type: 'login'; user: User; accessToken: string; refreshToken: string }
+  | { type: 'logout' };
 
 // ---------------------------------------------------------------------------
 // Context shape
@@ -88,6 +96,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const accessTokenRef = useRef<string | null>(null);
   const refreshTokenRef = useRef<string | null>(null);
 
+  // BroadcastChannel used to sync login/logout across tabs in the same browser.
+  // Held in a ref so all callbacks see the same instance.
+  const authChannelRef = useRef<BroadcastChannel | null>(null);
+
+  const postAuthMessage = useCallback((message: AuthBroadcastMessage) => {
+    authChannelRef.current?.postMessage(message);
+  }, []);
+
   // -----------------------------------------------------------------------
   // Token helpers
   // -----------------------------------------------------------------------
@@ -111,6 +127,76 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   useEffect(() => {
     setTokenAccessor(() => accessTokenRef.current);
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Register the unauthorized handler.
+  // Fires when any non-auth API call returns 401 — i.e. the session was
+  // invalidated server-side (most commonly because the user signed in on
+  // another browser, which our backend enforces by deleting prior sessions).
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    setUnauthorizedHandler((code) => {
+      // Idempotent: if we already cleared state, skip the duplicate toast.
+      if (accessTokenRef.current === null && refreshTokenRef.current === null) {
+        return;
+      }
+
+      accessTokenRef.current = null;
+      refreshTokenRef.current = null;
+      if (typeof window !== 'undefined') localStorage.removeItem(REFRESH_TOKEN_KEY);
+      setUser(null);
+
+      // Tell sibling tabs they're also logged out — they share localStorage
+      // and may have their own in-memory access token still loaded.
+      postAuthMessage({ type: 'logout' });
+
+      // Distinguish "kicked by another login" from a naturally-expired token.
+      // Backend returns UNAUTHORIZED for invalidated sessions and TOKEN_EXPIRED
+      // when the access token has aged out without a refresh.
+      if (code === 'TOKEN_EXPIRED') {
+        toast.error('Your session has expired. Please sign in again.');
+      } else {
+        toast.error('You were signed out because this account signed in on another device.');
+      }
+    });
+
+    return () => setUnauthorizedHandler(null);
+  }, [postAuthMessage]);
+
+  // -----------------------------------------------------------------------
+  // Cross-tab login/logout sync via BroadcastChannel.
+  // BroadcastChannel only delivers to OTHER tabs, so we never echo our own
+  // messages back into our state.
+  // -----------------------------------------------------------------------
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+
+    const channel = new BroadcastChannel(AUTH_CHANNEL_NAME);
+    authChannelRef.current = channel;
+
+    channel.onmessage = (event: MessageEvent<AuthBroadcastMessage>) => {
+      const msg = event.data;
+      if (msg.type === 'login') {
+        accessTokenRef.current = msg.accessToken;
+        refreshTokenRef.current = msg.refreshToken;
+        setUser(msg.user);
+      } else if (msg.type === 'logout') {
+        accessTokenRef.current = null;
+        refreshTokenRef.current = null;
+        // The originating tab already removed the localStorage entry.
+        setUser(null);
+      }
+    };
+
+    return () => {
+      channel.close();
+      authChannelRef.current = null;
+    };
   }, []);
 
   // -----------------------------------------------------------------------
@@ -162,8 +248,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const res = await authApi.register(data);
       saveTokens(res.data.accessToken, res.data.refreshToken);
       setUser(res.data.user);
+      postAuthMessage({
+        type: 'login',
+        user: res.data.user,
+        accessToken: res.data.accessToken,
+        refreshToken: res.data.refreshToken,
+      });
     },
-    [saveTokens]
+    [saveTokens, postAuthMessage]
   );
 
   const login = useCallback(
@@ -171,8 +263,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const res = await authApi.login(email, password);
       saveTokens(res.data.accessToken, res.data.refreshToken);
       setUser(res.data.user);
+      postAuthMessage({
+        type: 'login',
+        user: res.data.user,
+        accessToken: res.data.accessToken,
+        refreshToken: res.data.refreshToken,
+      });
     },
-    [saveTokens]
+    [saveTokens, postAuthMessage]
   );
 
   const googleLogin = useCallback(
@@ -180,8 +278,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       const res = await authApi.googleAuth(idToken);
       saveTokens(res.data.accessToken, res.data.refreshToken);
       setUser(res.data.user);
+      postAuthMessage({
+        type: 'login',
+        user: res.data.user,
+        accessToken: res.data.accessToken,
+        refreshToken: res.data.refreshToken,
+      });
     },
-    [saveTokens]
+    [saveTokens, postAuthMessage]
   );
 
   const logout = useCallback(async () => {
@@ -190,6 +294,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     // Optimistically clear local state
     clearTokens();
     setUser(null);
+    postAuthMessage({ type: 'logout' });
 
     // Fire-and-forget server logout
     if (rt) {
@@ -202,7 +307,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
       }
     }
-  }, [clearTokens]);
+  }, [clearTokens, postAuthMessage]);
 
   const refreshUser = useCallback(async () => {
     try {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -34,6 +34,24 @@ export const setTokenAccessor = (accessor: () => string | null): void => {
 };
 
 // =============================================================================
+// Unauthorized handler
+// =============================================================================
+// Fires when the backend returns 401 on any authenticated request OTHER than
+// the auth endpoints themselves (login/register/refresh — those handle their
+// own 401 semantics). AuthContext registers a handler that clears local state
+// and shows a "signed in elsewhere" toast.
+
+type UnauthorizedHandler = (reason: string) => void;
+let onUnauthorized: UnauthorizedHandler | null = null;
+
+/** Paths whose 401s are NOT treated as session-invalidation events. */
+const AUTH_BYPASS_PATHS = ['/auth/login', '/auth/register', '/auth/refresh', '/auth/google'];
+
+export const setUnauthorizedHandler = (handler: UnauthorizedHandler | null): void => {
+  onUnauthorized = handler;
+};
+
+// =============================================================================
 // Request helpers
 // =============================================================================
 
@@ -189,12 +207,21 @@ const request = async <T>(
       signal: options?.signal,
     });
 
-    return handleResponse<T>(response, method, url);
+    return await handleResponse<T>(response, method, url);
   } catch (error) {
     logError(method, url, error);
 
-    // Re-throw ApiErrors as-is
+    // Re-throw ApiErrors as-is, but first notify the unauthorized handler
+    // when a non-auth request hits 401. This is how the frontend learns the
+    // session was killed (e.g., the user logged in on another browser).
     if (error instanceof ApiError) {
+      if (
+        error.status === 401 &&
+        onUnauthorized &&
+        !AUTH_BYPASS_PATHS.some((p) => path.startsWith(p))
+      ) {
+        onUnauthorized(error.code);
+      }
       throw error;
     }
 


### PR DESCRIPTION
## Summary

Companion to **Dynasty-Futures/DF-Backend#4** (single-session enforcement). Two changes:

1. **Handle backend 401s as session-invalidation events.** When the backend kicks this browser (because the same user logged in elsewhere), the next API call 401s — we clear local auth state and surface a toast.
2. **Cross-tab sync via `BroadcastChannel`.** Logging in or out in one tab is instantly mirrored in sibling tabs of the same browser.

## How it works

### 401 handling (`src/services/api.ts`)

- New `setUnauthorizedHandler(fn)` accessor on the API client (same pattern as `setTokenAccessor`).
- When a request returns 401 *and* the path is not in `AUTH_BYPASS_PATHS` (`/auth/login`, `/auth/register`, `/auth/refresh`, `/auth/google` — those handle their own 401 semantics), the handler is invoked with the error code.

### `AuthContext` (`src/contexts/AuthContext.tsx`)

- Registers a handler that clears tokens, sets `user = null`, and shows a `sonner` toast.
- Toast message branches on the backend's error code:
  - `UNAUTHORIZED` → `"You were signed out because this account signed in on another device."`
  - `TOKEN_EXPIRED` → `"Your session has expired. Please sign in again."`
- Idempotent — if state is already cleared, skips the duplicate toast.
- After cleanup, broadcasts a `logout` message so sibling tabs also clear their state.
- `ProtectedRoute` handles the redirect to `/login` automatically once `user` becomes `null` (no extra wiring needed).

### `BroadcastChannel('df-auth')`

- Tabs post `{ type: 'login', user, accessToken, refreshToken }` on login/register/googleLogin, and `{ type: 'logout' }` on logout.
- `BroadcastChannel` only delivers to *other* tabs (not the sender), so no echo loops.
- Guarded on `typeof BroadcastChannel !== 'undefined'` for SSR safety (entry-server.tsx).

## Test plan

- [x] `npm run build` — clean (lint warnings are all pre-existing in untouched files)
- [ ] Manual: open Browser A and Browser B, log in to the same account in both. Confirm A's next click 401s and shows the "signed in on another device" toast.
- [ ] Manual: open two tabs in the same browser. Log in on tab 1 → tab 2 updates without reload. Log out on tab 1 → tab 2 logs out.
- [ ] Manual: let an access token expire naturally, then make an API call — confirm `"Your session has expired"` toast (not the "another device" one).