### PR TITLE
Add daily scheduled maintenance window rule to Rules page

### DIFF
--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -56,6 +56,13 @@ const universalRules = [
     allowed: false,
   },
   {
+    icon: ClockIcon,
+    title: "Daily Scheduled Maintenance",
+    description:
+      "Dynasty Futures observes a daily scheduled maintenance window from 4:20 PM Eastern Time to 6:00 PM Eastern Time, ending when the futures market reopens. During this time, platform access, account updates, trading availability, and system functions may be temporarily unavailable or limited.",
+    allowed: false,
+  },
+  {
     icon: Newspaper,
     title: "No News Trading",
     label: "News Trading Restriction",


### PR DESCRIPTION
## Summary

- Adds a new **"Daily Scheduled Maintenance"** rule to the `universalRules` array in `src/pages/Rules.tsx`
- Placed after "Weekend Holds NOT Allowed" alongside other time-based trading restrictions (overnight trading, weekend holds, news trading)
- Rule text: *"Dynasty Futures observes a daily scheduled maintenance window from 4:20 PM Eastern Time to 6:00 PM Eastern Time, ending when the futures market reopens. During this time, platform access, account updates, trading availability, and system functions may be temporarily unavailable or limited."*
- Marked `allowed: false` so it renders in the "Restricted & Limited" section of the accordion
- Uses the existing `ClockIcon` — no new imports needed

## What was NOT changed

- No existing rules modified
- No layout, styling, or spacing changes
- No pricing, payout, or FAQ content touched
- Mobile responsiveness preserved

## Test plan

- [ ] Visit `/rules` and confirm the "Daily Scheduled Maintenance" rule appears in the accordion
- [ ] Verify it shows under the restricted/limited filter (red X indicator)
- [ ] Confirm it sits near other time-based rules (overnight trading, weekend holds)
- [ ] Check mobile layout is unaffected

https://claude.ai/code/session_013psqznQ6MGcJ4BdwGwHKMw

---
_Generated by [Claude Code](https://claude.ai/code/session_013psqznQ6MGcJ4BdwGwHKMw)_