### PR TITLE
Remove Priority Support from Advanced Plan on Rules page

### DIFF
--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -210,7 +210,6 @@ const planRules = [
       "No consistency rule",
       "Immediate activation",
       "5-day payout cycles",
-      "Priority support",
       "Copy trading allowed",
       "One funded reset allowed per account",
     ],


### PR DESCRIPTION
## Summary
- Removes "Priority support" from the Advanced Plan features list in `src/pages/Rules.tsx`
- No other changes — layout, styling, spacing, and all other rules are untouched

## Test plan
- [ ] Visit the Rules page and confirm the Advanced Plan section no longer lists "Priority support"
- [ ] Confirm all other Advanced Plan features remain intact
- [ ] Confirm no other plan sections were affected

https://claude.ai/code/session_01SHwVNi6JRL4uBCukrzK2gn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHwVNi6JRL4uBCukrzK2gn)_