### PR TITLE
Update Refund & Cancellation Policy and add footer quick link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -12,6 +12,7 @@ const quickLinks = [
   { name: "Affiliates", path: "/affiliates" },
   { name: "Support", path: "/support" },
   { name: "Legal", path: "/legal" },
+  { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
 ];
 
 const Footer = () => {

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -1,10 +1,20 @@
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
 import PageMeta from "@/components/seo/PageMeta";
 import JsonLd, { breadcrumb } from "@/components/seo/JsonLd";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
+const VALID_TABS = ["risk", "terms", "privacy", "refund"];
+
 const Legal = () => {
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get("tab");
+  const [activeTab, setActiveTab] = useState(
+    VALID_TABS.includes(tabParam ?? "") ? tabParam! : "risk"
+  );
+
   return (
     <Layout>
       <PageMeta
@@ -33,7 +43,7 @@ const Legal = () => {
 
           {/* Tabs */}
           <ScrollReveal className="max-w-4xl mx-auto">
-            <Tabs defaultValue="risk" className="w-full">
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
               <TabsList className="w-full overflow-x-auto flex md:grid md:grid-cols-4 bg-muted/30 p-1 rounded-xl mb-8 gap-1 md:gap-0">
                 <TabsTrigger
                   value="risk"
@@ -450,13 +460,15 @@ const Legal = () => {
                     </p>
 
                     <h3 className="text-foreground font-display text-lg mt-6">
-                      Subscription Cancellations (If Applicable)
+                      Subscription Cancellations
                     </h3>
                     <p>
-                      If a subscription-based product is offered, users may
-                      cancel future billing at any time prior to the next
-                      billing cycle. Cancellation stops future charges but does
-                      not entitle the user to refunds for prior payments.
+                      Dynasty Futures evaluation accounts are subscription-based
+                      and renew monthly unless canceled before the next billing
+                      cycle. Users may cancel future billing at any time prior
+                      to renewal. Cancellation stops future charges but does not
+                      entitle the user to refunds for prior payments, active
+                      billing periods, or previously issued account access.
                     </p>
 
                     <h3 className="text-foreground font-display text-lg mt-6">


### PR DESCRIPTION
## Summary

- **Subscription Cancellations section rewritten** (`src/pages/Legal.tsx`): Removed the conditional "If a subscription-based product is offered" language. The section now clearly states that Dynasty Futures evaluation accounts are subscription-based, renew monthly unless canceled before the next billing cycle, and that cancellations do not entitle the user to refunds for prior payments, active billing periods, or previously issued account access.
- **Deep-link support added to Legal page**: The Legal page now reads a `?tab=` query parameter on load, so `/legal?tab=refund` opens directly to the Refund & Cancellation tab. Tab switching still works normally after load.
- **Footer Quick Links updated** (`src/components/layout/Footer.tsx`): Added "Refund & Cancellation Policy" linking to `/legal?tab=refund`, matching the existing link styling. Works on desktop and mobile.

## Test plan

- [ ] Visit `/legal` — defaults to Risk Disclosure tab (unchanged behavior)
- [ ] Visit `/legal?tab=refund` — opens directly to Refund & Cancellation tab
- [ ] Confirm Subscription Cancellations heading reads "Subscription Cancellations" (no "If Applicable")
- [ ] Confirm new policy text matches the approved copy
- [ ] Confirm All Sales Final, Rule Violations, Technical Issues, and Contact sections are unchanged
- [ ] Check footer Quick Links — "Refund & Cancellation Policy" appears and navigates to the correct tab
- [ ] Verify footer link styling matches other Quick Links on both desktop and mobile

https://claude.ai/code/session_019deMDjTwRK1MXbB91oBp3L

---
_Generated by [Claude Code](https://claude.ai/code/session_019deMDjTwRK1MXbB91oBp3L)_