### PR TITLE
Add FAQ: Do evaluation accounts renew monthly?

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -98,6 +98,12 @@ const faqs = [
       "Simply visit our Pricing page, choose your preferred plan and account size, and complete the checkout process. For Standard, Advanced, and Builder plans, you'll begin your evaluation challenge.",
   },
   {
+    id: "evaluation-renewal",
+    question: "Do evaluation accounts renew monthly?",
+    answer:
+      "Yes. Dynasty Futures evaluation accounts are subscription-based and renew monthly unless canceled before the next billing cycle. You may cancel future billing at any time prior to renewal. Cancellation stops future charges but does not entitle you to refunds for prior payments, active billing periods, or previously issued account access.",
+  },
+  {
     id: "profit-target",
     question: "What is the profit target?",
     answer:


### PR DESCRIPTION
## Summary

- Adds a new FAQ item: **"Do evaluation accounts renew monthly?"** to `src/pages/FAQ.tsx`
- Explains that evaluation accounts are subscription-based, renew monthly unless canceled before the next billing cycle, and that cancellation stops future charges but does not entitle refunds for prior payments or active billing periods
- Placed after the "How do I get started?" entry to keep billing/subscription questions grouped together
- No layout, styling, accordion behavior, or other FAQ items were changed

## Test plan

- [ ] Visit `/faq` and confirm the new question appears near the bottom of the billing/subscription section (after "How do I get started?")
- [ ] Open the accordion item and verify the full answer text is correct
- [ ] Confirm no other FAQ items were altered
- [ ] Confirm accordion expand/collapse behavior is unchanged

https://claude.ai/code/session_015Tydt2ikNPYomntMfLzqsw

---
_Generated by [Claude Code](https://claude.ai/code/session_015Tydt2ikNPYomntMfLzqsw)_