### PR TITLE
Add Restricted Countries legal tab and refund FAQ entry

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -104,6 +104,12 @@ const faqs = [
       "Yes. Dynasty Futures evaluation accounts are subscription-based and renew monthly unless canceled before the next billing cycle. You may cancel future billing at any time prior to renewal. Cancellation stops future charges but does not entitle you to refunds for prior payments, active billing periods, or previously issued account access.",
   },
   {
+    id: "are-purchases-refundable",
+    question: "Are purchases refundable?",
+    answer:
+      "No. Due to the digital and performance-based nature of simulated trading evaluations and immediate account delivery, all purchases made through Dynasty Futures are generally considered final once account access or platform credentials have been issued.\n\nIf you have a verified technical issue directly attributable to Dynasty Futures, our team may review the situation and provide an account credit, reset, or replacement at our sole discretion.",
+  },
+  {
     id: "profit-target",
     question: "What is the profit target?",
     answer:

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -6,7 +6,7 @@ import JsonLd, { breadcrumb } from "@/components/seo/JsonLd";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-const VALID_TABS = ["risk", "terms", "privacy", "refund"];
+const VALID_TABS = ["risk", "terms", "privacy", "refund", "restricted"];
 
 const Legal = () => {
   const [searchParams] = useSearchParams();
@@ -44,7 +44,7 @@ const Legal = () => {
           {/* Tabs */}
           <ScrollReveal className="max-w-4xl mx-auto">
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className="w-full overflow-x-auto flex md:grid md:grid-cols-4 bg-muted/30 p-1 rounded-xl mb-8 gap-1 md:gap-0">
+              <TabsList className="w-full overflow-x-auto flex md:grid md:grid-cols-5 bg-muted/30 p-1 rounded-xl mb-8 gap-1 md:gap-0">
                 <TabsTrigger
                   value="risk"
                   className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-shrink-0"
@@ -68,6 +68,12 @@ const Legal = () => {
                   className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-shrink-0"
                 >
                   Refund & Cancellation
+                </TabsTrigger>
+                <TabsTrigger
+                  value="restricted"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-shrink-0"
+                >
+                  Restricted Countries
                 </TabsTrigger>
               </TabsList>
 
@@ -496,6 +502,115 @@ const Legal = () => {
                       </a>
                       .
                     </p>
+                  </div>
+                </div>
+              </TabsContent>
+              <TabsContent value="restricted">
+                <div className="bg-gradient-card rounded-3xl border border-border/50 p-8 md:p-10">
+                  <h2 className="font-display text-2xl font-bold text-foreground mb-6">
+                    Restricted Countries & Regions
+                  </h2>
+
+                  <div className="prose prose-invert max-w-none space-y-6 text-muted-foreground">
+                    <p>
+                      Dynasty Futures does not currently accept users or account
+                      registrations from certain countries or regions due to U.S.
+                      compliance requirements, sanctions programs, payment
+                      processor limitations, identity verification restrictions,
+                      or internal risk controls.
+                    </p>
+
+                    <h3 className="text-foreground font-display text-lg mt-6">
+                      Restricted Countries & Regions
+                    </h3>
+                    <p>
+                      The following countries and regions are not eligible to
+                      register for or access Dynasty Futures services:
+                    </p>
+
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 not-prose">
+                      {[
+                        "Afghanistan",
+                        "Belarus",
+                        "Bosnia & Herzegovina",
+                        "Bulgaria",
+                        "Cambodia",
+                        "Central African Republic",
+                        "Congo (DRC)",
+                        "Crimea Region",
+                        "Cuba",
+                        "Donetsk Region",
+                        "Haiti",
+                        "Iran",
+                        "Iraq",
+                        "Lebanon",
+                        "Liberia",
+                        "Libya",
+                        "Luhansk Region",
+                        "Myanmar (Burma)",
+                        "North Korea",
+                        "Pakistan",
+                        "Russia",
+                        "Somalia",
+                        "South Sudan",
+                        "Sudan",
+                        "Syria",
+                        "Venezuela",
+                        "Yemen",
+                        "Zimbabwe",
+                      ].map((country) => (
+                        <div
+                          key={country}
+                          className="flex items-center gap-2 py-1.5 border-b border-border/30 text-sm text-muted-foreground"
+                        >
+                          <span className="w-1.5 h-1.5 rounded-full bg-destructive/70 flex-shrink-0" />
+                          {country}
+                        </div>
+                      ))}
+                    </div>
+
+                    <h3 className="text-foreground font-display text-lg mt-8">
+                      Additional Restricted or Limited Access Jurisdictions
+                    </h3>
+                    <p>
+                      Dynasty Futures may limit, deny, or manually review access
+                      from certain jurisdictions based on fraud prevention,
+                      payment processor restrictions, identity verification
+                      limitations, VPN/proxy usage, abnormal account activity,
+                      or internal compliance reviews.
+                    </p>
+
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-2 not-prose">
+                      {[
+                        "Botswana",
+                        "Ghana",
+                        "Indonesia",
+                        "Jamaica",
+                        "Nigeria",
+                        "Tanzania",
+                        "Turkey",
+                        "Vietnam",
+                      ].map((country) => (
+                        <div
+                          key={country}
+                          className="flex items-center gap-2 py-1.5 border-b border-border/30 text-sm text-muted-foreground"
+                        >
+                          <span className="w-1.5 h-1.5 rounded-full bg-amber-500/70 flex-shrink-0" />
+                          {country}
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className="mt-8 p-4 rounded-xl border border-border/50 bg-muted/20 text-sm">
+                      <p className="text-muted-foreground">
+                        Dynasty Futures reserves the right to restrict or deny
+                        access to any jurisdiction at its sole discretion for
+                        compliance, fraud prevention, identity verification,
+                        operational risk management, or payment processor
+                        requirements. Restricted jurisdictions may change at any
+                        time without notice.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </TabsContent>


### PR DESCRIPTION
## Summary

- **New legal tab**: Adds a "Restricted Countries & Regions" fifth tab to `/legal`, listing OFAC/sanctions-restricted countries (28 total) and additional risk-based review jurisdictions (8 total), with a compliance disclaimer at the bottom
- **FAQ entry**: Adds "Are purchases refundable?" item after the evaluation-renewal question, explaining the all-sales-final policy and the discretionary credit/reset option for verified technical issues
- Existing legal page layout, branding, typography, and all other pages are untouched

## Changes

### `src/pages/Legal.tsx`
- Added `"restricted"` to `VALID_TABS` (accessible via `?tab=restricted`)
- Updated `TabsList` from `md:grid-cols-4` to `md:grid-cols-5`
- Added `TabsTrigger` labeled "Restricted Countries"
- Added `TabsContent` with:
  - Introductory compliance paragraph
  - 2–3 column grid of 28 fully-restricted countries (red dot indicator)
  - Secondary section for 8 risk-based review jurisdictions (amber dot indicator)
  - Bottom disclaimer box about discretionary restriction authority

### `src/pages/FAQ.tsx`
- Added `"are-purchases-refundable"` FAQ item after `"evaluation-renewal"`, matching existing accordion structure and hash-navigation pattern

## Test plan
- [ ] Visit `/legal` — confirm five tabs render, "Restricted Countries" tab is last
- [ ] Visit `/legal?tab=restricted` — confirm deep-link lands on the correct tab
- [ ] Confirm country grid displays cleanly on mobile and desktop
- [ ] Visit `/faq` — confirm "Are purchases refundable?" accordion item appears after the evaluation-renewal question
- [ ] Confirm all existing legal tabs and FAQ items are unchanged

https://claude.ai/code/session_012HDFUs4uBCN3J538Qy1REg

---
_Generated by [Claude Code](https://claude.ai/code/session_012HDFUs4uBCN3J538Qy1REg)_