### PR TITLE
Update pricing page disclaimer text

### DIFF
--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -553,8 +553,7 @@ const Pricing = () => {
 
                 {/* Disclaimer */}
                 <p className="text-sm text-muted-foreground mt-6 text-center">
-                  All plans renew monthly. Cancel anytime. Reset fees are
-                  one-time and never billed monthly.
+                  Evaluation accounts are subscription-based and renew monthly unless canceled prior to the next billing cycle. You may cancel at any time before renewal. Reset fees are one-time purchases and are never billed monthly.
                 </p>
               </ScrollReveal>
             </section>


### PR DESCRIPTION
## Summary

- Replaces the brief pricing disclaimer with clearer, more professional wording
- Explicitly states that evaluation accounts are subscription-based and renew monthly unless canceled before the next billing cycle
- Clarifies that reset fees are one-time purchases, never billed monthly
- No styling, layout, or structural changes — text content only

## Test plan

- [ ] Visit `/pricing` and confirm the updated disclaimer appears beneath the pricing cards
- [ ] Verify layout is visually clean on mobile and desktop
- [ ] Confirm no other pricing section content was affected

https://claude.ai/code/session_01NyH5FAnyiJcbcqSZ8a1Nwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyH5FAnyiJcbcqSZ8a1Nwz)_