### PR TITLE
Update pricing card: cleaner CTA button and larger plan logos

### DIFF
--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -450,7 +450,7 @@ const Pricing = () => {
                     >
                       <PlanImage
                         plan={plan}
-                        size={36}
+                        size={64}
                         className={
                           selectedPlan === plan
                             ? "brightness-0 invert drop-shadow-sm"
@@ -547,7 +547,7 @@ const Pricing = () => {
                     onClick={() => handleSelect(selectedPlan, sizeNum)}
                     className="px-10"
                   >
-                    {isLoading ? "Loading..." : `Get Started — ${selectedSize}`}
+                    {isLoading ? "Loading..." : "Get Started"}
                   </Button>
                 </div>
 


### PR DESCRIPTION
## Summary

- **CTA button text**: Removed account size from the "Get Started" button — it now reads simply "Get Started" for all plans and account sizes
- **Plan logo size**: Increased plan selector logos (Standard, Advanced, Builder) from 36px to 64px for improved visual prominence and readability

## Changes

- `src/pages/Pricing.tsx` — two targeted edits only; no layout, pricing data, or functionality was touched

## Test plan

- [ ] Visit `/pricing` and confirm button reads "Get Started" (no dollar amount appended)
- [ ] Switch between account sizes and confirm button text stays "Get Started"
- [ ] Switch between Standard, Advanced, and Builder plans and confirm logos are visibly larger and remain centered/balanced
- [ ] Verify logos do not overflow or distort on mobile and desktop viewports
- [ ] Confirm all other pricing page elements (table, selectors, disclaimer, styling) are unchanged

https://claude.ai/code/session_013nrnWKAV2vegzZ88euRr94

---
_Generated by [Claude Code](https://claude.ai/code/session_013nrnWKAV2vegzZ88euRr94)_