### PR TITLE
Update footer support hours to 24/7 and fix mobile pricing card sizing

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -135,7 +135,7 @@ const Footer = () => {
             </h4>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>support@dynastyfuturesdyn.com</li>
-              <li>Mon - Fri: 9AM - 6PM EST</li>
+              <li>Available 24 hours a day, 7 days a week</li>
             </ul>
           </div>
         </div>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -436,13 +436,13 @@ const Pricing = () => {
             <section className="mb-20">
               <ScrollReveal className="glass-card-strong rounded-3xl border border-border/50 overflow-hidden p-8 md:p-12">
                 {/* Plan Selector */}
-                <div className="flex flex-wrap justify-center gap-3 mb-6">
+                <div className="grid grid-cols-3 sm:flex sm:flex-wrap sm:justify-center gap-2 sm:gap-3 mb-6">
                   {(Object.keys(planConfig) as PlanKey[]).map((plan) => (
                     <button
                       key={plan}
                       onClick={() => handlePlanChange(plan)}
                       className={cn(
-                        "px-8 py-6 rounded-xl font-display font-semibold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col items-center gap-2.5 min-w-[180px]",
+                        "px-2 py-4 sm:px-8 sm:py-6 rounded-xl font-display font-semibold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col items-center justify-center gap-2 sm:gap-2.5 h-full sm:h-auto min-w-0 sm:min-w-[180px]",
                         selectedPlan === plan
                           ? "bg-gradient-to-r from-gold-dark via-primary to-gold-light text-white border border-primary/60 shadow-lg shadow-primary/20"
                           : "border border-border/50 text-muted-foreground hover:border-primary/40 hover:text-foreground bg-transparent",
@@ -451,11 +451,12 @@ const Pricing = () => {
                       <PlanImage
                         plan={plan}
                         size={64}
-                        className={
+                        className={cn(
+                          "w-8 h-8 sm:w-16 sm:h-16",
                           selectedPlan === plan
                             ? "brightness-0 invert drop-shadow-sm"
-                            : undefined
-                        }
+                            : undefined,
+                        )}
                       />
                       <span>{planConfig[plan].label}</span>
                       <span


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Footer:** Replace "Mon - Fri: 9AM - 6PM EST" with "Available 24 hours a day, 7 days a week" in the Contact section
- **Mobile pricing cards:** Switch the plan selector container to a CSS grid (`grid-cols-3`) on mobile so all three cards are equal width and height; scale icons and padding down on mobile to prevent overflow; restore the original `flex` layout on `sm:` and above

## Changes

### `src/components/layout/Footer.tsx`
- Updated support hours copy from limited business hours to 24/7 wording

### `src/pages/Pricing.tsx`
- Plan selector wrapper: `grid grid-cols-3` on mobile → `sm:flex sm:flex-wrap` on desktop (preserves existing desktop layout exactly)
- Card buttons: responsive padding (`px-2 py-4` mobile / `sm:px-8 sm:py-6` desktop), `h-full` on mobile so grid row stretch makes all cards the same height, `justify-center` to vertically center content
- PlanImage: `w-8 h-8` on mobile / `sm:w-16 sm:h-16` on desktop — prevents icon overflow on narrow cards

## Test plan

- [ ] Mobile (≤640px): all three plan selector cards are the same width and height
- [ ] Mobile: active (gold) card keeps its styling but does not differ in size from inactive cards
- [ ] Mobile: plan icons are centered and not clipped
- [ ] Desktop (≥640px): pricing layout is unchanged
- [ ] Footer: "Available 24 hours a day, 7 days a week" appears in the Contact column
- [ ] Support page wording is unchanged
- [ ] Pricing data, account size selectors, and CTA buttons are unaffected

https://claude.ai/code/session_01JAvFQfFUzfdHBZ123RExwp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAvFQfFUzfdHBZ123RExwp)_