### PR TITLE
Footer: move Support to Contact, add Restricted Countries link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,9 +10,9 @@ const quickLinks = [
   { name: "Rules", path: "/rules" },
   { name: "FAQ", path: "/faq" },
   { name: "Affiliates", path: "/affiliates" },
-  { name: "Support", path: "/support" },
   { name: "Legal", path: "/legal" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
+  { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
 ];
 
 const Footer = () => {
@@ -136,6 +136,15 @@ const Footer = () => {
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>support@dynastyfuturesdyn.com</li>
               <li>Available 24 hours a day, 7 days a week</li>
+              <li>
+                <Link
+                  to="/support"
+                  onClick={handleLinkClick}
+                  className="hover:text-primary transition-colors duration-300 link-transition inline-block"
+                >
+                  Support
+                </Link>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Move Support link** — removed from Quick Links, added as a clickable link under the Contact column (below email and availability hours)
- **Add Restricted Countries & Regions** — new Quick Link placed after Refund & Cancellation Policy, linking to `/legal?tab=restricted` (the existing restricted tab on the Legal page)
- No other footer changes: layout, logo, social icons, legal disclosure card, disclaimer text, and all other links are untouched

## Test plan

- [ ] Footer Contact column shows: email → availability hours → Support link (clickable, routes to `/support`)
- [ ] Footer Quick Links no longer shows "Support"
- [ ] Footer Quick Links shows "Restricted Countries & Regions" near the bottom, links to `/legal?tab=restricted` and opens that tab correctly
- [ ] Footer layout, logo, social icons, and legal disclosure are unchanged on both mobile and desktop

https://claude.ai/code/session_01U6DP7PH2fmpj6BmFxR4Ndu

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6DP7PH2fmpj6BmFxR4Ndu)_