### PR TITLE
Update footer: move Support to Contact, add Restricted Countries & Regions link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,9 +10,9 @@ const quickLinks = [
   { name: "Rules", path: "/rules" },
   { name: "FAQ", path: "/faq" },
   { name: "Affiliates", path: "/affiliates" },
-  { name: "Support", path: "/support" },
   { name: "Legal", path: "/legal" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
+  { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
 ];
 
 const Footer = () => {
@@ -136,6 +136,15 @@ const Footer = () => {
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li>support@dynastyfuturesdyn.com</li>
               <li>Available 24 hours a day, 7 days a week</li>
+              <li>
+                <Link
+                  to="/support"
+                  onClick={handleLinkClick}
+                  className="hover:text-primary transition-colors duration-300 link-transition inline-block"
+                >
+                  Support
+                </Link>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **Move Support link**: Removed "Support" from Quick Links column and added it as a clickable link under the Contact column (below the email and availability text)
- **Add Restricted Countries & Regions**: Added a new Quick Link pointing to `/legal?tab=restricted`, placed after the existing legal/refund links for visual consistency
- No other footer changes — layout, branding, social icons, legal disclosure text, and all other links are untouched

## Test plan

- [ ] Verify "Support" no longer appears in the Quick Links column
- [ ] Verify "Support" appears under Contact and routes to `/support`
- [ ] Verify "Restricted Countries & Regions" appears in Quick Links and routes to `/legal?tab=restricted` (opens the Restricted Countries tab on the Legal page)
- [ ] Confirm footer layout, logo, social icons, and disclosure text are unchanged on desktop and mobile

https://claude.ai/code/session_01K8XwLJgLkL8mVMxsFyR9eS

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8XwLJgLkL8mVMxsFyR9eS)_