### PR TITLE
Fix legal page tabs wrapping — single row layout with horizontal scroll on mobile

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -42,52 +42,54 @@ const Legal = () => {
           </ScrollReveal>
 
           {/* Tabs */}
-          <ScrollReveal className="max-w-4xl mx-auto">
+          <ScrollReveal className="max-w-6xl mx-auto">
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className="w-full flex flex-wrap bg-muted/30 p-1.5 rounded-xl mb-8 gap-1.5">
+              <div className="overflow-x-auto mb-8">
+              <TabsList className="flex flex-nowrap w-full min-w-max bg-muted/30 p-1.5 rounded-xl gap-3">
                 <TabsTrigger
                   value="risk"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Risk Disclosure
                 </TabsTrigger>
                 <TabsTrigger
                   value="terms"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Terms of Use
                 </TabsTrigger>
                 <TabsTrigger
                   value="privacy"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Privacy Policy
                 </TabsTrigger>
                 <TabsTrigger
                   value="refund"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Refund & Cancellation
                 </TabsTrigger>
                 <TabsTrigger
                   value="restricted"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Restricted Countries
                 </TabsTrigger>
                 <TabsTrigger
                   value="rise-payouts"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   Rise Payouts
                 </TabsTrigger>
                 <TabsTrigger
                   value="kyc-aml"
-                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-4 py-2 text-xs sm:text-sm"
+                  className="rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground whitespace-nowrap px-3 py-2 text-xs sm:text-sm flex-1"
                 >
                   KYC & AML Policy
                 </TabsTrigger>
               </TabsList>
+              </div>
 
               <TabsContent value="risk">
                 <div className="bg-gradient-card rounded-3xl border border-border/50 p-8 md:p-10">


### PR DESCRIPTION
## Summary

- **Widens container** from `max-w-4xl` to `max-w-6xl` so all 7 tabs have enough room to sit in one row on desktop
- **Removes `flex-wrap`** on the tab list and wraps it in an `overflow-x-auto` div — tabs never stack awkwardly; they scroll horizontally on narrow screens instead
- **Adds `flex-1`** to each trigger so tabs distribute evenly across the full bar width (premium, evenly-spaced look)
- **Increases gap** between tabs from `gap-1.5` → `gap-3` and slightly reduces internal padding `px-4` → `px-3` to ensure clean fit without sacrificing readability
- All active-state styling (gold highlight, colors, fonts, dark theme) is unchanged
- No content, routes, or other page sections were modified

## Test plan

- [ ] Visit `/legal` on a large desktop (1280px+) — all 7 tabs appear in one clean horizontal row
- [ ] Click each tab to confirm active gold styling still works
- [ ] Resize to ~1024px — tabs remain on one row (container is now wide enough)
- [ ] Resize to mobile — tabs scroll horizontally instead of wrapping or stacking
- [ ] Deep-link to `/legal?tab=kyc-aml` — KYC & AML Policy tab activates correctly

https://claude.ai/code/session_01BJAbJBd2UH8m8e6TPDAtzS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJAbJBd2UH8m8e6TPDAtzS)_