### PR TITLE
Remove duplicate Contact Support button from legal support CTAs

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -988,16 +988,10 @@ const Legal = () => {
                     </p>
                     <div className="flex flex-wrap gap-3 mb-4">
                       <a
-                        href="/support"
+                        href="https://www.dynastyfuturesdyn.com/support"
                         className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors duration-200"
                       >
                         Open Support Center
-                      </a>
-                      <a
-                        href="/support"
-                        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-primary/40 bg-primary/10 text-primary text-sm font-semibold hover:bg-primary/20 hover:border-primary/60 transition-all duration-200"
-                      >
-                        Contact Support
                       </a>
                     </div>
                     <p className="text-xs text-muted-foreground">
@@ -1331,16 +1325,10 @@ const Legal = () => {
                     </p>
                     <div className="flex flex-wrap gap-3 mb-4">
                       <a
-                        href="/support"
+                        href="https://www.dynastyfuturesdyn.com/support"
                         className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors duration-200"
                       >
                         Open Support Center
-                      </a>
-                      <a
-                        href="/support"
-                        className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-primary/40 bg-primary/10 text-primary text-sm font-semibold hover:bg-primary/20 hover:border-primary/60 transition-all duration-200"
-                      >
-                        Contact Support
                       </a>
                     </div>
                     <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

- Removed the duplicate "Contact Support" button from the **Rise Payouts** support CTA section
- Removed the duplicate "Contact Support" button from the **KYC & AML Policy** support CTA section
- Updated the remaining "Open Support Center" button href from `/support` to `https://www.dynastyfuturesdyn.com/support` in both sections

Support email and availability text are unchanged. No layout, styling, or legal content was modified.

## Test plan

- [ ] Navigate to the Legal & Risk Disclosure page → Rise Payouts tab — confirm only one "Open Support Center" button is visible
- [ ] Navigate to KYC & AML Policy tab — confirm only one "Open Support Center" button is visible
- [ ] Click "Open Support Center" in each section — confirm it links to `https://www.dynastyfuturesdyn.com/support`
- [ ] Confirm support email and "Available 24 hours a day, 7 days a week" text remain intact in both sections
- [ ] Confirm Refund & Cancellation Policy tab is unaffected

https://claude.ai/code/session_01NXLsdAaVgWjvhJ6yc95mGC

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXLsdAaVgWjvhJ6yc95mGC)_