### PR TITLE
Add Dynasty Articles footer column and fix Terms of Use Trading Rules link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,12 +10,24 @@ const quickLinks = [
   { name: "Rules", path: "/rules" },
   { name: "FAQ", path: "/faq" },
   { name: "Affiliates", path: "/affiliates" },
-  { name: "Legal", path: "/legal" },
-  { name: "Essential Trading Rules Overview", path: "/legal?tab=trading-rules" },
+  { name: "Legal / Terms of Use", path: "/legal?tab=terms" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
   { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
-  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
+];
+
+const dynastyArticleLinks = [
+  { name: "Essential Trading Rules Overview", path: "/legal?tab=trading-rules" },
   { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
+  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
+  { name: "Daily Loss Limit Explained", path: "/legal?tab=trading-rules&rule=daily-loss" },
+  { name: "Drawdown Rules Explained", path: "/legal?tab=trading-rules&rule=drawdown" },
+  { name: "News Trading Policy", path: "/legal?tab=trading-rules&rule=news-trading" },
+  { name: "Consistency Rule Explained", path: "/legal?tab=trading-rules&rule=consistency" },
+  { name: "Position Size Limits", path: "/legal?tab=trading-rules&rule=position-size" },
+  { name: "Profit Targets Explained", path: "/legal?tab=trading-rules&rule=profit-targets" },
+  { name: "Payouts & Profit Split", path: "/legal?tab=trading-rules&rule=payouts-split" },
+  { name: "Account Violations & Resets", path: "/legal?tab=trading-rules&rule=violations" },
+  { name: "Copy Trading & Automated Systems Policy", path: "/legal?tab=trading-rules&rule=copy-trading" },
 ];
 
 const Footer = () => {
@@ -31,7 +43,7 @@ const Footer = () => {
       <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent" />
 
       <div className="container mx-auto px-4 py-12 md:py-16">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 md:gap-12">
           {/* Logo & Description */}
           <div className="flex flex-col justify-between min-h-[160px]">
             <div className="flex-1 flex items-center justify-start">
@@ -128,6 +140,26 @@ const Footer = () => {
                   Pre-Launch Announcement
                 </button>
               </li>
+            </ul>
+          </div>
+
+          {/* Dynasty Articles */}
+          <div>
+            <h4 className="font-display font-semibold text-foreground mb-4">
+              Dynasty Articles
+            </h4>
+            <ul className="space-y-2">
+              {dynastyArticleLinks.map((link) => (
+                <li key={link.path}>
+                  <Link
+                    to={link.path}
+                    onClick={handleLinkClick}
+                    className="text-muted-foreground text-sm hover:text-primary transition-colors duration-300 link-transition inline-block"
+                  >
+                    {link.name}
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
 

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -227,7 +227,7 @@ const Legal = () => {
                     </div>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 my-4">
                       {[
-                        { label: "Trading Rules", tab: "", href: "/rules" },
+                        { label: "Trading Rules", tab: "trading-rules" },
                         { label: "Risk Disclosure", tab: "risk" },
                         { label: "Refund & Cancellation Policy", tab: "refund" },
                         { label: "KYC & AML Policy", tab: "kyc-aml" },
@@ -369,7 +369,7 @@ const Legal = () => {
                     </div>
                     <div className="mt-4 p-4 rounded-xl border border-border/50 bg-muted/20 text-sm text-muted-foreground">
                       Full rule definitions are available on the{" "}
-                      <a href="/rules" className="text-primary hover:underline font-medium">Trading Rules page</a>.
+                      <button onClick={() => setActiveTab("trading-rules")} className="text-primary hover:underline font-medium">Trading Rules page</button>.
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary

- **New footer column "Dynasty Articles"** — added between Quick Links and Contact with 12 links: Essential Trading Rules Overview, KYC & AML Policy, Rise Payout Guide, and 9 rule-explainer sub-articles (Daily Loss Limit, Drawdown Rules, News Trading Policy, Consistency Rule, Position Size Limits, Profit Targets, Payouts & Profit Split, Account Violations & Resets, Copy Trading & Automated Systems Policy)
- **Quick Links updated** — "Legal" renamed to "Legal / Terms of Use" (now routes to `/legal?tab=terms`); Essential Trading Rules Overview, KYC & AML Policy, and Rise Payout Guide moved out into Dynasty Articles
- **Footer grid** updated from 3-column to 4-column responsive layout (`sm:grid-cols-2 lg:grid-cols-4`)
- **Terms of Use fix** — "Trading Rules" button in the policy list now navigates to `/legal?tab=trading-rules` (Help & Legal Center) instead of `/rules` (main Rules page); secondary inline link in section 6 also updated

## Test plan

- [ ] Footer renders correctly at mobile (1 col), tablet (2 col), and desktop (4 col) breakpoints
- [ ] "Dynasty Articles" column appears between Quick Links and Contact
- [ ] All 12 Dynasty Articles links route to the correct `/legal?tab=...` pages (including `&rule=` sub-articles)
- [ ] "Legal / Terms of Use" in Quick Links opens the Terms tab at `/legal?tab=terms`
- [ ] Terms of Use page: clicking "Trading Rules" in the policy grid opens the trading-rules tab (not the `/rules` page)
- [ ] Terms of Use section 6: clicking "Trading Rules page" inline link switches to the trading-rules tab
- [ ] Contact column, social icons, disclosure banner, and disclaimer text are unchanged
- [ ] Footer styling, colors, fonts, and branding are unchanged

https://claude.ai/code/session_01RWmbAGNZLF73xLFrUvMnY4

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWmbAGNZLF73xLFrUvMnY4)_