### PR TITLE
Add Open Support Center CTA to Privacy Policy and Refund & Cancellation Policy

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -775,6 +775,24 @@ const Legal = () => {
                       contact us at support@dynastyfuturesdyn.com.
                     </p>
                   </div>
+
+                  <div className="p-6 rounded-2xl border border-border/50 bg-muted/20 mt-6">
+                    <h3 className="font-display text-lg font-semibold text-foreground mb-2">
+                      Questions About This Policy?
+                    </h3>
+                    <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+                      If you have questions about this Privacy Policy or how we handle your data, please contact our support team.
+                    </p>
+                    <a
+                      href="https://www.dynastyfuturesdyn.com/support"
+                      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors duration-200"
+                    >
+                      Open Support Center
+                    </a>
+                    <p className="text-xs text-muted-foreground mt-4">
+                      support@dynastyfuturesdyn.com · Available 24 hours a day, 7 days a week
+                    </p>
+                  </div>
                 </div>
               </TabsContent>
 
@@ -852,6 +870,24 @@ const Legal = () => {
                         support@dynastyfuturesdyn.com
                       </a>
                       .
+                    </p>
+                  </div>
+
+                  <div className="p-6 rounded-2xl border border-border/50 bg-muted/20 mt-6">
+                    <h3 className="font-display text-lg font-semibold text-foreground mb-2">
+                      Questions About This Policy?
+                    </h3>
+                    <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+                      If you have questions about this Refund & Cancellation Policy, please contact our support team.
+                    </p>
+                    <a
+                      href="https://www.dynastyfuturesdyn.com/support"
+                      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-semibold hover:bg-primary/90 transition-colors duration-200"
+                    >
+                      Open Support Center
+                    </a>
+                    <p className="text-xs text-muted-foreground mt-4">
+                      support@dynastyfuturesdyn.com · Available 24 hours a day, 7 days a week
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- Adds the "Open Support Center" button CTA block to the **Privacy Policy** tab
- Adds the "Open Support Center" button CTA block to the **Refund & Cancellation Policy** tab
- Both blocks match the identical style and structure used in all other Help & Legal Center tabs (Terms of Use, KYC & AML, Rise Payouts, Chargebacks)

## What changed

Both tabs now display the same support callout card found on the other legal tabs:
- Title: "Questions About This Policy?"
- Short description directing users to support
- "Open Support Center" button linking to `https://www.dynastyfuturesdyn.com/support`
- `support@dynastyfuturesdyn.com · Available 24 hours a day, 7 days a week` footer text

No policy wording was changed. No other tabs were touched.

## Test plan

- [ ] Navigate to `/legal?tab=privacy` — confirm the "Open Support Center" button appears below the policy content
- [ ] Navigate to `/legal?tab=refund` — confirm the "Open Support Center" button appears below the policy content
- [ ] Verify the button style matches the existing CTA on the Terms of Use, KYC & AML, Rise Payouts, and Chargebacks tabs
- [ ] Confirm the support email remains visible in both sections
- [ ] Confirm no other tabs were altered

https://claude.ai/code/session_01GDVma1zPQuDxvdp1zcSEcB

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDVma1zPQuDxvdp1zcSEcB)_