### PR TITLE
Update payout language: remove 80/20 split references, clarify 90/10 and live review process

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -119,13 +119,13 @@ const faqs = [
     id: "profit-split",
     question: "What is the profit split for funded traders?",
     answer:
-      "Funded traders receive a 90/10 profit split — you keep 90% of all profits generated in your funded account. After completing five (5) approved payouts, the account transitions into our long-term payout structure with an 80/20 profit split, where 80% of future profits go to the trader and 20% is retained by Dynasty Futures.",
+      "Dynasty Futures funded accounts operate on a 90/10 profit split. Traders keep 90% of approved profits, while Dynasty Futures retains 10%. The profit split does not automatically change after five payouts.",
   },
   {
     id: "five-payouts",
     question: "What happens after I receive five payouts?",
     answer:
-      "After completing five (5) approved payouts, your account transitions into our long-term payout structure with an 80/20 profit split — 80% of future profits go to the trader and 20% is retained by Dynasty Futures. Prior to reaching five payouts, the standard funded profit split is 90/10.",
+      "After five approved payouts, Dynasty Futures may internally review the account for potential live trading consideration. Reviews may include trading consistency, compliance history, payout history, risk management, operational availability, and jurisdictional eligibility. Transition to a live environment is not guaranteed and remains at the sole discretion of Dynasty Futures.",
   },
 ];
 

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -762,10 +762,16 @@ const Pricing = () => {
             <ScrollReveal as="section" className="mb-12">
               <div className="glass-card rounded-2xl border border-border/50 p-6 md:p-8 text-center">
                 <h2 className="font-display text-xl font-semibold text-foreground mb-3">
-                  Profit Split & Long Term Payout Structure
+                  Profit Split & Payout Structure
                 </h2>
+                <p className="text-muted-foreground max-w-2xl mx-auto text-sm mb-3">
+                  Funded accounts operate on a <span className="text-foreground font-semibold">90/10 profit split</span>. Traders keep 90% of approved profits, while Dynasty Futures retains 10%.
+                </p>
+                <p className="text-muted-foreground max-w-2xl mx-auto text-sm mb-3">
+                  After five approved payouts, accounts may be internally reviewed for potential live trading consideration based on consistency, risk management, compliance history, operational availability, platform/broker support, and jurisdictional eligibility.
+                </p>
                 <p className="text-muted-foreground max-w-2xl mx-auto text-sm">
-                  Funded accounts operate on a <span className="text-foreground font-semibold">90/10 profit split</span> — you keep 90% of all profits. After five approved payouts, traders move into our long-term payout structure with an <span className="text-foreground font-semibold">80/20 profit split</span>, with 80% going to the trader. There is no forced transition to a live account at that stage. Many traders prefer staying in the environment they already know, and we built this structure to support that choice.
+                  Transition to a live trading environment is not guaranteed and remains subject to Dynasty Futures approval, operational readiness, legal/compliance requirements, and jurisdictional availability.
                 </p>
               </div>
             </ScrollReveal>

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -148,9 +148,9 @@ const universalRules = [
   },
   {
     icon: DollarIcon,
-    title: "Funded Profit Split & Long Term Payout Structure",
+    title: "Funded Profit Split",
     description:
-      "Funded accounts operate on a 90/10 profit split — 90% of profits go to the trader. After five (5) approved payouts, the account transitions into our long term payout structure with an 80/20 profit split, where 80% of all future profits go to the trader. This milestone reflects consistency and performance, and we designed the structure around it. Traders are not required to transition to a live account at that stage. Many prefer staying in the environment they already know and trust, and we want to preserve that continuity while supporting long term growth.",
+      "Funded accounts operate on a 90/10 profit split, with traders keeping 90% of approved profits. After five (5) approved payouts, accounts may be internally reviewed for potential live trading consideration based on consistency, risk management, compliance history, operational availability, broker/platform support, and jurisdictional eligibility. Live trading placement is not guaranteed and remains subject to Dynasty Futures approval and applicable legal/compliance requirements.",
     allowed: true,
   },
 ];


### PR DESCRIPTION
## Summary

- **Pricing page**: Updated "Profit Split & Long Term Payout Structure" card to remove all 80/20 and long-term payout structure language. Now clearly states 90/10 split, describes the discretionary internal review after five approved payouts, and notes that live trading placement is not guaranteed.
- **Rules page**: Updated the "Funded Profit Split & Long Term Payout Structure" rule entry to remove 80/20 references and replace with accurate language about the 90/10 split and discretionary live trading review process.
- **FAQ page**: Updated both payout-related questions:
  - "What is the profit split?" — now states 90/10, no automatic change after five payouts.
  - "What happens after five payouts?" — now describes the internal review process and that live transition is not guaranteed.

## What was removed
- All references to an automatic 80/20 profit split transition
- All references to a "long-term payout structure"
- Language implying the profit split automatically changes after five payouts

## What was added
- Clear statement that funded accounts use a 90/10 profit split (no automatic change)
- After five approved payouts, Dynasty Futures may conduct an internal review for potential live trading consideration
- Live trading placement is not guaranteed and remains subject to Dynasty Futures' sole discretion, operational availability, compliance review, platform/broker support, and jurisdictional eligibility

## Test plan
- [ ] Visit `/pricing` — confirm the payout card no longer mentions 80/20 or long-term payout structure
- [ ] Visit `/rules` — confirm the funded profit split rule reflects 90/10 only with discretionary review language
- [ ] Visit `/faq` — confirm both profit split and five-payout questions use updated wording
- [ ] Search the rendered site for "80/20" — should return no results

https://claude.ai/code/session_01W7wxzCAgDoXueFAc1u7PSP

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7wxzCAgDoXueFAc1u7PSP)_