### PR TITLE
Dashboard: DeepCharts button, sidebar labels, accounts restructure, empty states, affiliate modal

### DIFF
--- a/src/components/dashboard/BuyChallengeButton.tsx
+++ b/src/components/dashboard/BuyChallengeButton.tsx
@@ -1,36 +1,6 @@
-import { useState } from 'react';
-import { Loader2, Plus } from 'lucide-react';
-import { toast } from 'sonner';
+import { Plus } from 'lucide-react';
+import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { checkoutApi } from '@/services/checkout';
-import { ApiError } from '@/types/api';
-
-type Plan = 'standard' | 'advanced' | 'dynasty';
-type Size = 25000 | 50000 | 100000 | 150000;
-
-const PLAN_LABELS: Record<Plan, string> = {
-  standard: 'Standard (Evaluation)',
-  advanced: 'Advanced (Instant Activation)',
-  dynasty: 'Dynasty (Instant Funding)',
-};
-
-const SIZE_OPTIONS: Size[] = [25000, 50000, 100000, 150000];
 
 interface BuyChallengeButtonProps {
   variant?: 'default' | 'outline' | 'ghost';
@@ -43,114 +13,15 @@ const BuyChallengeButton = ({
   variant = 'default',
   size = 'sm',
   className,
-  label = 'Buy Challenge',
+  label = 'New Challenge',
 }: BuyChallengeButtonProps) => {
-  const [open, setOpen] = useState(false);
-  const [plan, setPlan] = useState<Plan>('standard');
-  const [accountSize, setAccountSize] = useState<Size>(50000);
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleCheckout = async () => {
-    setSubmitting(true);
-    try {
-      const res = await checkoutApi.createSession(plan, accountSize);
-      const url = res.data?.checkoutUrl;
-      if (!url) {
-        toast.error('Could not create checkout session.');
-        return;
-      }
-      window.location.href = url;
-    } catch (err) {
-      const msg =
-        err instanceof ApiError
-          ? err.message
-          : err instanceof Error
-            ? err.message
-            : 'Checkout failed';
-      toast.error(msg);
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const formatSize = (n: number) =>
-    `$${n.toLocaleString()}`;
-
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant={variant} size={size} className={className}>
-          <Plus size={14} className="mr-2" />
-          {label}
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-[440px]">
-        <DialogHeader>
-          <DialogTitle>Buy a Challenge</DialogTitle>
-          <DialogDescription>
-            Choose a plan and account size. You'll be redirected to Stripe to
-            complete payment.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="space-y-4 py-2">
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">
-              Plan
-            </label>
-            <Select value={plan} onValueChange={(v) => setPlan(v as Plan)}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PLAN_LABELS) as Plan[]).map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {PLAN_LABELS[p]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">
-              Account Size
-            </label>
-            <Select
-              value={String(accountSize)}
-              onValueChange={(v) => setAccountSize(Number(v) as Size)}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SIZE_OPTIONS.map((s) => (
-                  <SelectItem key={s} value={String(s)}>
-                    {formatSize(s)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button
-            variant="ghost"
-            onClick={() => setOpen(false)}
-            disabled={submitting}
-          >
-            Cancel
-          </Button>
-          <Button onClick={handleCheckout} disabled={submitting}>
-            {submitting && (
-              <Loader2 size={14} className="mr-2 animate-spin" />
-            )}
-            Continue to Checkout
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <Button variant={variant} size={size} className={className} asChild>
+      <Link to="/pricing">
+        <Plus size={14} className="mr-2" />
+        {label}
+      </Link>
+    </Button>
   );
 };
 

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -8,18 +8,12 @@ import {
   Users,
   User,
   Award,
-  Headphones
+  Headphones,
+  Tag,
+  ExternalLink,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-  TooltipPortal,
-} from '@/components/ui/tooltip';
 
-/** Same asset as <link rel="icon"> in index.html */
 const siteIconSrc = '/favicon.png?v=20260406';
 
 const sidebarLinks = [
@@ -45,64 +39,70 @@ const DashboardSidebar = () => {
   };
 
   return (
-    <TooltipProvider delayDuration={0}>
-      <aside className="w-16 shrink-0 h-screen sticky top-0 bg-transparent backdrop-blur-xl border-r border-border/30 flex flex-col overflow-hidden">
-        {/* Logo */}
-        <div className="p-3 flex justify-center bg-transparent">
-          <Link to="/" className="group">
-            <img
-              src={siteIconSrc}
-              alt="Dynasty Futures"
-              className="h-10 w-10 object-contain transition-transform duration-300 group-hover:scale-105 logo-blend"
-            />
-          </Link>
-        </div>
+    <aside className="w-52 shrink-0 h-screen sticky top-0 bg-transparent backdrop-blur-xl border-r border-border/30 flex flex-col overflow-hidden">
+      {/* Logo + Home link */}
+      <div className="px-4 py-4 flex flex-col items-center gap-2 border-b border-border/20">
+        <Link to="/" className="group">
+          <img
+            src={siteIconSrc}
+            alt="Dynasty Futures"
+            className="h-10 w-10 object-contain transition-transform duration-300 group-hover:scale-105 logo-blend"
+          />
+        </Link>
+        <a
+          href="https://www.dynastyfuturesdyn.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ExternalLink size={10} />
+          Home
+        </a>
+      </div>
 
-        {/* Navigation */}
-        <nav className="flex-1 p-2 space-y-1">
-          {sidebarLinks.map((link) => {
-            const Icon = link.icon;
-            const active = isActive(link.path);
-            
-            return (
-              <Tooltip key={link.path}>
-                <TooltipTrigger asChild>
-                  <Link
-                    to={link.path}
-                    className={cn(
-                      "flex items-center justify-center p-3 rounded-xl transition-all duration-300",
-                      active 
-                        ? "bg-primary/10 text-primary border border-primary/20" 
-                        : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-                    )}
-                  >
-                    <Icon 
-                      size={22} 
-                      className={cn(
-                        "transition-colors duration-300",
-                        active ? "text-primary" : ""
-                      )} 
-                    />
-                  </Link>
-                </TooltipTrigger>
-                <TooltipPortal>
-                  <TooltipContent side="right" className="font-medium z-50">
-                    {link.name}
-                  </TooltipContent>
-                </TooltipPortal>
-              </Tooltip>
-            );
-          })}
-        </nav>
+      {/* Navigation */}
+      <nav className="flex-1 p-3 space-y-0.5 overflow-y-auto">
+        {sidebarLinks.map((link) => {
+          const Icon = link.icon;
+          const active = isActive(link.path);
 
-        {/* Footer */}
-        <div className="p-2 border-t border-border/30">
-        <p className="text-[10px] text-muted-foreground text-center">
-          © 2026
-        </p>
-        </div>
-      </aside>
-    </TooltipProvider>
+          return (
+            <Link
+              key={link.path}
+              to={link.path}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all duration-300',
+                active
+                  ? 'bg-primary/10 text-primary border border-primary/20'
+                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+              )}
+            >
+              <Icon
+                size={18}
+                className={cn('shrink-0 transition-colors duration-300', active ? 'text-primary' : '')}
+              />
+              <span className="text-sm font-medium truncate">{link.name}</span>
+            </Link>
+          );
+        })}
+
+        {/* Pricing — external link */}
+        <a
+          href="https://www.dynastyfuturesdyn.com/pricing"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-all duration-300"
+        >
+          <Tag size={18} className="shrink-0" />
+          <span className="text-sm font-medium">Pricing</span>
+        </a>
+      </nav>
+
+      {/* Footer */}
+      <div className="p-3 border-t border-border/30">
+        <p className="text-[10px] text-muted-foreground text-center">© 2026</p>
+      </div>
+    </aside>
   );
 };
 

--- a/src/components/dashboard/OpenPlatformButton.tsx
+++ b/src/components/dashboard/OpenPlatformButton.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useDashboardUrl } from '@/hooks/useTrading';
 import { toast } from 'sonner';
@@ -48,9 +48,9 @@ const OpenPlatformButton = ({
       {isFetching ? (
         <Loader2 size={14} className="mr-2 animate-spin" />
       ) : (
-        <ExternalLink size={14} className="mr-2" />
+        <img src="/deepcharts-logo.png" alt="" className="h-4 w-4 mr-2 object-contain" />
       )}
-      Open Platform
+      DeepCharts
     </Button>
   );
 };

--- a/src/pages/Affiliates.tsx
+++ b/src/pages/Affiliates.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Layout from "@/components/layout/Layout";
 import PageMeta from "@/components/seo/PageMeta";
 import JsonLd, { breadcrumb, faqPageSchema } from "@/components/seo/JsonLd";
@@ -25,6 +26,7 @@ import {
   BarChart2,
   Clock,
 } from "lucide-react";
+import AffiliateRegistrationModal from "@/components/dashboard/AffiliateRegistrationModal";
 
 const tradeFirstCards = [
   {
@@ -201,6 +203,8 @@ const affiliateFaqs = [
 ];
 
 const Affiliates = () => {
+  const [isAffiliateModalOpen, setIsAffiliateModalOpen] = useState(false);
+
   return (
     <Layout>
       <PageMeta
@@ -268,12 +272,12 @@ const Affiliates = () => {
                   </Link>
                 </Button>
                 <Button
-                  asChild
                   variant="outline"
                   size="lg"
                   className="border-border/50 hover:border-primary/50 hover:text-primary"
+                  onClick={() => setIsAffiliateModalOpen(true)}
                 >
-                  <Link to="/support">Apply to Become an Affiliate</Link>
+                  Apply to Become an Affiliate
                 </Button>
               </div>
             </div>
@@ -716,12 +720,12 @@ const Affiliates = () => {
                   </Link>
                 </Button>
                 <Button
-                  asChild
                   variant="outline"
                   size="lg"
                   className="border-border/50 hover:border-primary/50 hover:text-primary"
+                  onClick={() => setIsAffiliateModalOpen(true)}
                 >
-                  <Link to="/support">Apply to Become an Affiliate</Link>
+                  Apply to Become an Affiliate
                 </Button>
               </div>
             </div>
@@ -729,6 +733,11 @@ const Affiliates = () => {
 
         </div>
       </div>
+
+      <AffiliateRegistrationModal
+        open={isAffiliateModalOpen}
+        onOpenChange={setIsAffiliateModalOpen}
+      />
     </Layout>
   );
 };

--- a/src/pages/dashboard/DashboardAccounts.tsx
+++ b/src/pages/dashboard/DashboardAccounts.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Eye, ChevronRight, RotateCcw, AlertCircle, Loader2 } from "lucide-react";
+import { Eye, ChevronRight, RotateCcw, AlertCircle, Loader2, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
@@ -20,7 +20,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import ScrollReveal from "@/components/ui/ScrollReveal";
-import BuyChallengeButton from "@/components/dashboard/BuyChallengeButton";
 import { useTradingAccounts } from "@/hooks/useTrading";
 import type { TradingAccount, AccountStatus } from "@/types/trading";
 
@@ -102,10 +101,6 @@ const getStageBadge = (stage: StageLabel): string => {
   return styles[stage];
 };
 
-type FilterStatus = "All" | StatusLabel;
-
-const STATUS_FILTERS: FilterStatus[] = ["All", "Active", "Violated", "Closed"];
-
 // =============================================================================
 // Reset pricing
 // TODO: Replace with real plan/size pricing data from CRM or pricing API once
@@ -174,16 +169,164 @@ function getResetPriceInfo(account: AccountView): ResetPriceInfo | null {
   };
 }
 
+const truncateId = (id: string) => id.length > 12 ? `${id.slice(0, 8)}…` : id;
+
 // =============================================================================
-// Component
+// Sub-components
+// =============================================================================
+
+interface ActiveAccountsTableProps {
+  accounts: AccountView[];
+  onReset: (account: AccountView) => void;
+}
+
+const ActiveAccountsTable = ({ accounts, onReset }: ActiveAccountsTableProps) => {
+  if (accounts.length === 0) {
+    return (
+      <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-10 text-center text-muted-foreground">
+        <p className="font-medium text-foreground mb-1">No active accounts yet</p>
+        <p className="text-sm">Purchase a challenge to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-border/30 hover:bg-transparent">
+            <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Balance</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {accounts.map((account, index) => (
+            <TableRow
+              key={account.id}
+              className={`border-border/30 hover:bg-muted/20 transition-colors border-l-2 border-l-primary ${
+                index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+              }`}
+            >
+              <TableCell className="font-mono text-xs text-muted-foreground py-4">
+                {truncateId(account.id)}
+              </TableCell>
+              <TableCell className="text-foreground py-4">{account.planType}</TableCell>
+              <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
+              <TableCell className="py-4">
+                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
+                  {account.stage}
+                </span>
+              </TableCell>
+              <TableCell className="py-4">
+                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
+                  {account.status}
+                </span>
+              </TableCell>
+              <TableCell className="font-semibold text-foreground py-4">{account.balance}</TableCell>
+              <TableCell className="text-right py-4">
+                <div className="flex items-center justify-end gap-2">
+                  {account.isResettable && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70 transition-all"
+                      onClick={() => onReset(account)}
+                    >
+                      <RotateCcw size={14} className="mr-2" />
+                      Reset
+                    </Button>
+                  )}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50 transition-all"
+                    asChild
+                  >
+                    <Link to={`/dashboard?account=${account.id}`}>
+                      <Eye size={16} className="mr-2" />
+                      View
+                      <ChevronRight size={14} className="ml-1" />
+                    </Link>
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+interface InactiveAccountsTableProps {
+  accounts: AccountView[];
+}
+
+const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
+  if (accounts.length === 0) {
+    return (
+      <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-10 text-center text-muted-foreground">
+        <p className="font-medium text-foreground mb-1">No inactive accounts</p>
+        <p className="text-sm">Closed or violated accounts will appear here.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-border/30 hover:bg-transparent">
+            <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {accounts.map((account, index) => (
+            <TableRow
+              key={account.id}
+              className={`border-border/30 hover:bg-muted/20 transition-colors ${
+                index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+              }`}
+            >
+              <TableCell className="font-mono text-xs text-muted-foreground py-4">
+                {truncateId(account.id)}
+              </TableCell>
+              <TableCell className="text-foreground py-4">{account.planType}</TableCell>
+              <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
+              <TableCell className="py-4">
+                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
+                  {account.stage}
+                </span>
+              </TableCell>
+              <TableCell className="py-4">
+                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
+                  {account.status}
+                </span>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+// =============================================================================
+// Main Component
 // =============================================================================
 
 const DashboardAccounts = () => {
   const { data, isLoading, isError, error } = useTradingAccounts();
 
-  const [statusFilter, setStatusFilter] = useState<FilterStatus>("All");
-  const [planFilter, setPlanFilter] = useState<string>("All");
-  // Account staged for the reset confirmation modal (null = modal closed)
   const [resetModalAccount, setResetModalAccount] = useState<AccountView | null>(null);
 
   const accounts = useMemo<AccountView[]>(
@@ -191,47 +334,27 @@ const DashboardAccounts = () => {
     [data],
   );
 
-  const planOptions = useMemo<string[]>(() => {
-    const set = new Set<string>();
-    for (const a of accounts) set.add(a.planType);
-    return ["All", ...Array.from(set).sort()];
-  }, [accounts]);
-
-  const filteredAccounts = useMemo(
-    () =>
-      accounts.filter((a) => {
-        if (statusFilter !== "All" && a.status !== statusFilter) return false;
-        if (planFilter !== "All" && a.planType !== planFilter) return false;
-        return true;
-      }),
-    [accounts, statusFilter, planFilter],
-  );
-
-  // First resettable account across all accounts (used by the header button).
-  const firstResettable = useMemo(
-    () => accounts.find((a) => a.isResettable) ?? null,
+  const activeAccounts = useMemo(
+    () => accounts.filter((a) => a.status === "Active"),
     [accounts],
   );
 
-  const hasResettableAccounts = firstResettable !== null;
+  const inactiveAccounts = useMemo(
+    () => accounts.filter((a) => a.status !== "Active"),
+    [accounts],
+  );
 
   const openResetModal = (account: AccountView) => setResetModalAccount(account);
   const closeResetModal = () => setResetModalAccount(null);
 
   // TODO: Connect to CRM account lookup, billing/checkout, and account reset
-  //       API once integration is complete. Required values:
-  //         selectedAccountId, selectedPlan, selectedAccountSize,
-  //         selectedAccountStatus, resetType, resetPrice.
+  //       API once integration is complete.
   const handleContinueToReset = () => {
-    toast.info(
-      "Reset checkout will be available once account billing is connected.",
-    );
+    toast.info("Reset checkout will be available once account billing is connected.");
     closeResetModal();
   };
 
-  const resetPriceInfo = resetModalAccount
-    ? getResetPriceInfo(resetModalAccount)
-    : null;
+  const resetPriceInfo = resetModalAccount ? getResetPriceInfo(resetModalAccount) : null;
 
   return (
     <div className="space-y-10 pt-16 lg:pt-0">
@@ -240,29 +363,14 @@ const DashboardAccounts = () => {
         <div className="flex items-start justify-between gap-4">
           <div>
             <h1 className="text-2xl font-bold text-foreground">Accounts</h1>
-            <p className="text-muted-foreground mt-1">
-              Manage your trading accounts
-            </p>
+            <p className="text-muted-foreground mt-1">Manage your trading accounts</p>
           </div>
-
-          {/* Header-level Reset Account button — enabled when a resettable account exists */}
-          <div className="flex flex-col items-end gap-1 shrink-0">
-            <Button
-              variant="outline"
-              size="sm"
-              className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70 transition-all"
-              disabled={!hasResettableAccounts || isLoading}
-              onClick={() => firstResettable && openResetModal(firstResettable)}
-            >
-              <RotateCcw size={14} className="mr-2" />
-              Reset Account
-            </Button>
-            {!isLoading && !hasResettableAccounts && accounts.length > 0 && (
-              <p className="text-xs text-muted-foreground/60">
-                Account reset available on active evaluations
-              </p>
-            )}
-          </div>
+          <Button asChild size="sm">
+            <Link to="/pricing">
+              <Plus size={14} className="mr-2" />
+              New Challenge
+            </Link>
+          </Button>
         </div>
       </ScrollReveal>
 
@@ -278,9 +386,7 @@ const DashboardAccounts = () => {
         <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 flex items-start gap-3">
           <AlertCircle className="text-destructive shrink-0 mt-0.5" size={20} />
           <div>
-            <p className="font-medium text-foreground">
-              Failed to load accounts
-            </p>
+            <p className="font-medium text-foreground">Failed to load accounts</p>
             <p className="text-sm text-muted-foreground mt-1">
               {error?.message ?? "Please try again."}
             </p>
@@ -288,169 +394,35 @@ const DashboardAccounts = () => {
         </div>
       )}
 
-      {/* Empty state */}
-      {!isLoading && !isError && accounts.length === 0 && (
-        <ScrollReveal delay={150}>
-          <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-12 text-center">
-            <h2 className="text-xl font-semibold text-foreground">
-              No accounts yet
-            </h2>
-            <p className="text-muted-foreground mt-2 mb-6">
-              Purchase a challenge to get started.
-            </p>
-            <div className="flex items-center justify-center gap-3">
-              <BuyChallengeButton size="default" />
-              <Button asChild variant="outline">
-                <Link to="/pricing">Browse Plans</Link>
-              </Button>
-            </div>
+      {/* Active Accounts */}
+      {!isLoading && !isError && (
+        <ScrollReveal delay={150} className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="w-2 h-2 rounded-full bg-primary" />
+            <h2 className="text-lg font-semibold text-foreground">Active Accounts</h2>
+            {activeAccounts.length > 0 && (
+              <span className="text-xs text-muted-foreground bg-muted/40 border border-border/30 px-2 py-0.5 rounded-full">
+                {activeAccounts.length}
+              </span>
+            )}
           </div>
+          <ActiveAccountsTable accounts={activeAccounts} onReset={openResetModal} />
         </ScrollReveal>
       )}
 
-      {/* Filters + table */}
-      {!isLoading && !isError && accounts.length > 0 && (
-        <ScrollReveal delay={150} className="space-y-10">
-          <div className="flex flex-wrap gap-6">
-            {/* Plan Type Filter */}
-            <div className="space-y-2">
-              <span className="text-sm text-muted-foreground">Plan Type</span>
-              <div className="flex items-center gap-2 flex-wrap">
-                {planOptions.map((plan) => (
-                  <Button
-                    key={plan}
-                    variant="ghost"
-                    size="sm"
-                    className={`px-4 py-2 rounded-lg text-sm transition-all ${
-                      planFilter === plan
-                        ? "bg-primary/20 text-primary border border-primary/30"
-                        : "text-muted-foreground hover:text-foreground border border-border/30"
-                    }`}
-                    onClick={() => setPlanFilter(plan)}
-                  >
-                    {plan}
-                  </Button>
-                ))}
-              </div>
-            </div>
-
-            {/* Status Filter */}
-            <div className="space-y-2">
-              <span className="text-sm text-muted-foreground">Status</span>
-              <div className="flex items-center gap-2">
-                {STATUS_FILTERS.map((status) => (
-                  <Button
-                    key={status}
-                    variant="ghost"
-                    size="sm"
-                    className={`px-4 py-2 rounded-lg text-sm transition-all ${
-                      statusFilter === status
-                        ? "bg-primary/20 text-primary border border-primary/30"
-                        : "text-muted-foreground hover:text-foreground border border-border/30"
-                    }`}
-                    onClick={() => setStatusFilter(status)}
-                  >
-                    {status}
-                  </Button>
-                ))}
-              </div>
-            </div>
+      {/* Inactive Accounts */}
+      {!isLoading && !isError && (
+        <ScrollReveal delay={250} className="space-y-4">
+          <div className="flex items-center gap-3">
+            <div className="w-2 h-2 rounded-full bg-muted-foreground/40" />
+            <h2 className="text-lg font-semibold text-foreground">Inactive Accounts</h2>
+            {inactiveAccounts.length > 0 && (
+              <span className="text-xs text-muted-foreground bg-muted/40 border border-border/30 px-2 py-0.5 rounded-full">
+                {inactiveAccounts.length}
+              </span>
+            )}
           </div>
-
-          {/* Accounts Table */}
-          <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
-            <Table>
-              <TableHeader>
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Start Date
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Plan Type
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Account Size
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Stage
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Status
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5">
-                    Balance
-                  </TableHead>
-                  <TableHead className="text-muted-foreground font-medium py-5 text-right">
-                    Actions
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredAccounts.map((account, index) => (
-                  <TableRow
-                    key={account.id}
-                    className={`border-border/30 hover:bg-muted/20 transition-colors ${
-                      index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
-                    } ${account.status === "Active" ? "border-l-2 border-l-primary" : ""}`}
-                  >
-                    <TableCell className="font-medium text-foreground py-5">
-                      {account.startDate}
-                    </TableCell>
-                    <TableCell className="text-foreground py-5">
-                      {account.planType}
-                    </TableCell>
-                    <TableCell className="text-foreground py-5">
-                      {account.accountSize}
-                    </TableCell>
-                    <TableCell className="py-5">
-                      <span
-                        className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}
-                      >
-                        {account.stage}
-                      </span>
-                    </TableCell>
-                    <TableCell className="py-5">
-                      <span
-                        className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}
-                      >
-                        {account.status}
-                      </span>
-                    </TableCell>
-                    <TableCell className="font-semibold text-foreground py-5">
-                      {account.balance}
-                    </TableCell>
-                    <TableCell className="text-right py-5">
-                      <div className="flex items-center justify-end gap-2">
-                        {account.isResettable && (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70 transition-all"
-                            onClick={() => openResetModal(account)}
-                          >
-                            <RotateCcw size={14} className="mr-2" />
-                            Reset Account
-                          </Button>
-                        )}
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50 transition-all"
-                          asChild
-                        >
-                          <Link to={`/dashboard?account=${account.id}`}>
-                            <Eye size={16} className="mr-2" />
-                            View
-                            <ChevronRight size={14} className="ml-1" />
-                          </Link>
-                        </Button>
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+          <InactiveAccountsTable accounts={inactiveAccounts} />
         </ScrollReveal>
       )}
 
@@ -463,7 +435,6 @@ const DashboardAccounts = () => {
               <div className="space-y-4 pt-1">
                 {resetModalAccount && (
                   <>
-                    {/* Account details summary */}
                     <div className="rounded-xl border border-border/30 bg-muted/20 p-4 space-y-2 text-sm">
                       <div className="flex justify-between">
                         <span className="text-muted-foreground">Account</span>
@@ -490,7 +461,6 @@ const DashboardAccounts = () => {
                         </>
                       )}
                     </div>
-
                     <p className="text-sm text-muted-foreground">
                       Resetting this account will require a reset purchase.
                       {resetPriceInfo
@@ -503,12 +473,8 @@ const DashboardAccounts = () => {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-2 sm:gap-2">
-            <Button variant="outline" onClick={closeResetModal}>
-              Cancel
-            </Button>
-            <Button onClick={handleContinueToReset}>
-              Continue to Reset
-            </Button>
+            <Button variant="outline" onClick={closeResetModal}>Cancel</Button>
+            <Button onClick={handleContinueToReset}>Continue to Reset</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -10,13 +10,13 @@ import {
   Calendar,
   Loader2,
   AlertCircle,
+  Plus,
 } from "lucide-react";
 import { format, isToday } from "date-fns";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import AccountSelector from "@/components/dashboard/AccountSelector";
 import OpenPlatformButton from "@/components/dashboard/OpenPlatformButton";
-import BuyChallengeButton from "@/components/dashboard/BuyChallengeButton";
 import MetricCard from "@/components/dashboard/MetricCard";
 import PerformanceChart from "@/components/dashboard/PerformanceChart";
 import SummaryPanel from "@/components/dashboard/SummaryPanel";
@@ -33,7 +33,6 @@ const DashboardHome = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const qc = useQueryClient();
 
-  // Toast + cache invalidation when returning from successful Stripe checkout.
   useEffect(() => {
     if (searchParams.get("checkout") === "success") {
       toast.success(
@@ -49,7 +48,6 @@ const DashboardHome = () => {
   const accountsQ = useTradingAccounts();
   const accounts = useMemo(() => accountsQ.data?.data ?? [], [accountsQ.data]);
 
-  // Selected account: ?account=ID query param wins, else first account.
   const urlAccountId = searchParams.get("account") ?? undefined;
   const [selectedAccount, setSelectedAccount] = useState<string>(
     urlAccountId ?? "",
@@ -70,7 +68,6 @@ const DashboardHome = () => {
     refetchInterval: 30_000,
   });
 
-  // Merge live balance over the adapted view so top metrics show real-time.
   const accountData = useMemo(() => {
     if (!view.data) return null;
     const live = liveQ.data?.data;
@@ -84,7 +81,6 @@ const DashboardHome = () => {
 
   const isBuilderAccount = accountData?.planType === "Builder";
 
-  // Real-data chart; daily view aligns to the user-selected calendar date.
   const chartData = useMemo(() => {
     if (!accountData) return [];
     return buildChartData(
@@ -103,12 +99,11 @@ const DashboardHome = () => {
   };
 
   const scrollToStats = () => {
-    document
-      .getElementById("stats-section")
-      ?.scrollIntoView({ behavior: "smooth" });
+    document.getElementById("stats-section")?.scrollIntoView({ behavior: "smooth" });
   };
 
-  // Loading the accounts list itself
+  const hasAccounts = accounts.length > 0;
+
   if (accountsQ.isLoading) {
     return (
       <div className="flex items-center justify-center py-20 text-muted-foreground">
@@ -117,7 +112,6 @@ const DashboardHome = () => {
     );
   }
 
-  // List failed
   if (accountsQ.isError) {
     return (
       <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 flex items-start gap-3">
@@ -127,35 +121,6 @@ const DashboardHome = () => {
           <p className="text-sm text-muted-foreground mt-1">
             {accountsQ.error?.message ?? "Please try again."}
           </p>
-        </div>
-      </div>
-    );
-  }
-
-  // No accounts → empty state
-  if (accounts.length === 0) {
-    return (
-      <div className="space-y-10 pt-16 lg:pt-0">
-        <div>
-          <h1 className="text-2xl font-bold text-foreground">Dashboard</h1>
-          <p className="text-muted-foreground mt-1">
-            Get started by purchasing your first challenge.
-          </p>
-        </div>
-        <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-12 text-center">
-          <h2 className="text-xl font-semibold text-foreground">
-            No accounts yet
-          </h2>
-          <p className="text-muted-foreground mt-2 mb-6">
-            Once you purchase a challenge, your trading dashboard will populate
-            here.
-          </p>
-          <div className="flex items-center justify-center gap-3">
-            <BuyChallengeButton size="default" />
-            <Button asChild variant="outline">
-              <Link to="/pricing">Browse Plans</Link>
-            </Button>
-          </div>
         </div>
       </div>
     );
@@ -173,168 +138,195 @@ const DashboardHome = () => {
             </p>
           </div>
           <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
-            {/* Date Range Selector */}
-            <div className="flex items-center gap-1 p-1 rounded-xl bg-muted/20 border border-border/30">
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "daily" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("daily")}
-              >
-                Daily
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "weekly" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("weekly")}
-              >
-                Weekly
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={`px-2.5 py-1.5 rounded-lg text-xs transition-all ${dateRange === "monthly" ? "bg-primary/20 text-primary" : "text-muted-foreground hover:text-foreground"}`}
-                onClick={() => setDateRange("monthly")}
-              >
-                Monthly
-              </Button>
-            </div>
-            <AccountSelector
-              value={selectedAccount}
-              onValueChange={setSelectedAccount}
-            />
-            <OpenPlatformButton />
-            <BuyChallengeButton variant="outline" />
+            {hasAccounts && (
+              <>
+                {/* Date Range Selector */}
+                <div className="flex items-center gap-1 p-1 rounded-xl bg-muted/20 border border-border/30">
+                  {["daily", "weekly", "monthly"].map((range) => (
+                    <Button
+                      key={range}
+                      variant="ghost"
+                      size="sm"
+                      className={`px-2.5 py-1.5 rounded-lg text-xs transition-all capitalize ${
+                        dateRange === range
+                          ? "bg-primary/20 text-primary"
+                          : "text-muted-foreground hover:text-foreground"
+                      }`}
+                      onClick={() => setDateRange(range)}
+                    >
+                      {range.charAt(0).toUpperCase() + range.slice(1)}
+                    </Button>
+                  ))}
+                </div>
+                <AccountSelector
+                  value={selectedAccount}
+                  onValueChange={setSelectedAccount}
+                />
+                <OpenPlatformButton />
+              </>
+            )}
+            {/* New Challenge button — always visible in top-right */}
+            <Button asChild size="sm" variant={hasAccounts ? "outline" : "default"}>
+              <Link to="/pricing">
+                <Plus size={14} className="mr-2" />
+                New Challenge
+              </Link>
+            </Button>
           </div>
         </div>
       </ScrollReveal>
 
-      {/* Loading the selected account view */}
-      {view.isLoading && !accountData && (
+      {/* Loading selected account view */}
+      {hasAccounts && view.isLoading && !accountData && (
         <div className="flex items-center justify-center py-20 text-muted-foreground">
           <Loader2 className="animate-spin mr-2" size={18} /> Loading account…
         </div>
       )}
 
-      {accountData && (
-        <>
-          {/* Key Metrics */}
-          <ScrollReveal delay={150}>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-              <MetricCard
-                title="Account Balance"
-                value={formatCurrency(accountData.currentBalance)}
-                icon={Wallet}
-                trend={accountData.closedPnL >= 0 ? "up" : "down"}
-                trendValue={formatCurrency(accountData.closedPnL, true)}
-              />
-              <MetricCard
-                title="Closed P&L"
-                value={formatCurrency(accountData.closedPnL, true)}
-                icon={TrendingUp}
-                trend={accountData.closedPnL >= 0 ? "up" : "down"}
-                trendValue={`${((accountData.closedPnL / Math.max(accountData.startingBalance, 1)) * 100).toFixed(1)}%`}
-              />
-              <MetricCard
-                title="Drawdown Used"
-                value={formatCurrency(accountData.drawdownUsed)}
-                icon={ShieldAlert}
-                trend="neutral"
-                trendValue={`of ${formatCurrency(accountData.maxDrawdown)}`}
-              />
-            </div>
+      {/* Metrics — always shown; zeros when no account data */}
+      <ScrollReveal delay={150}>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <MetricCard
+            title="Account Balance"
+            value={accountData ? formatCurrency(accountData.currentBalance) : "$0"}
+            icon={Wallet}
+            trend={accountData ? (accountData.closedPnL >= 0 ? "up" : "down") : "neutral"}
+            trendValue={accountData ? formatCurrency(accountData.closedPnL, true) : "—"}
+          />
+          <MetricCard
+            title="Closed P&L"
+            value={accountData ? formatCurrency(accountData.closedPnL, true) : "$0"}
+            icon={TrendingUp}
+            trend={accountData ? (accountData.closedPnL >= 0 ? "up" : "down") : "neutral"}
+            trendValue={
+              accountData
+                ? `${((accountData.closedPnL / Math.max(accountData.startingBalance, 1)) * 100).toFixed(1)}%`
+                : "0.0%"
+            }
+          />
+          <MetricCard
+            title="Drawdown Used"
+            value={accountData ? formatCurrency(accountData.drawdownUsed) : "$0"}
+            icon={ShieldAlert}
+            trend="neutral"
+            trendValue={accountData ? `of ${formatCurrency(accountData.maxDrawdown)}` : "of $0"}
+          />
+        </div>
 
-            <div className="flex justify-center">
-              <button
-                onClick={scrollToStats}
-                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-primary hover:text-primary/80 transition-colors group"
-              >
-                <span>Jump to Stats</span>
-                <ChevronDown size={16} className="animate-bounce" />
-              </button>
-            </div>
+        {accountData && (
+          <div className="flex justify-center">
+            <button
+              onClick={scrollToStats}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-primary hover:text-primary/80 transition-colors group"
+            >
+              <span>Jump to Stats</span>
+              <ChevronDown size={16} className="animate-bounce" />
+            </button>
+          </div>
+        )}
 
-            <PerformanceChart
-              data={chartData}
-              chartType={chartType}
-              onChartTypeChange={setChartType}
-              startingBalance={accountData.startingBalance}
-              timeframe={dateRange}
-              className="h-[calc(100vh-380px)] min-h-[400px]"
-            />
-          </ScrollReveal>
+        {/* Performance Chart */}
+        {accountData ? (
+          <PerformanceChart
+            data={chartData}
+            chartType={chartType}
+            onChartTypeChange={setChartType}
+            startingBalance={accountData.startingBalance}
+            timeframe={dateRange}
+            className="h-[calc(100vh-380px)] min-h-[400px]"
+          />
+        ) : (
+          <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm flex flex-col items-center justify-center min-h-[300px] text-muted-foreground mt-3">
+            <BarChart3 size={40} className="mb-3 opacity-30" />
+            <p className="text-sm font-medium">No trading data yet</p>
+            <p className="text-xs mt-1 opacity-60">Purchase a challenge to start tracking performance</p>
+          </div>
+        )}
+      </ScrollReveal>
 
-          {/* Stats Section */}
-          <ScrollReveal delay={300}>
-            <div id="stats-section" className="pt-8">
-              <div className="flex items-center gap-2 mb-6">
-                <BarChart3 size={20} className="text-primary" />
-                <h2 className="text-lg font-semibold text-foreground">
-                  Performance Overview
-                </h2>
-              </div>
+      {/* Stats Section */}
+      <ScrollReveal delay={300}>
+        <div id="stats-section" className="pt-8">
+          <div className="flex items-center gap-2 mb-6">
+            <BarChart3 size={20} className="text-primary" />
+            <h2 className="text-lg font-semibold text-foreground">Performance Overview</h2>
+          </div>
 
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <Map size={14} className="text-muted-foreground" />
-                    <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-                      {isBuilderAccount ? "Payout Tracker" : "Account Roadmap"}
-                    </span>
-                  </div>
-                  {isBuilderAccount ? (
-                    <BuilderPanel
-                      accountId={selectedAccount}
-                      selectedDate={selectedDate}
-                      onDateChange={setSelectedDate}
-                    />
-                  ) : (
-                    <SummaryPanel
-                      accountId={selectedAccount}
-                      selectedDate={selectedDate}
-                      onDateChange={setSelectedDate}
-                    />
-                  )}
+          {accountData ? (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Map size={14} className="text-muted-foreground" />
+                  <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
+                    {isBuilderAccount ? "Payout Tracker" : "Account Roadmap"}
+                  </span>
                 </div>
-
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <BarChart3 size={14} className="text-muted-foreground" />
-                    <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
-                      Trading Analytics
-                    </span>
-                  </div>
-                  <AccountMetrics accountId={selectedAccount} />
+                {isBuilderAccount ? (
+                  <BuilderPanel
+                    accountId={selectedAccount}
+                    selectedDate={selectedDate}
+                    onDateChange={setSelectedDate}
+                  />
+                ) : (
+                  <SummaryPanel
+                    accountId={selectedAccount}
+                    selectedDate={selectedDate}
+                    onDateChange={setSelectedDate}
+                  />
+                )}
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <BarChart3 size={14} className="text-muted-foreground" />
+                  <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
+                    Trading Analytics
+                  </span>
                 </div>
+                <AccountMetrics accountId={selectedAccount} />
               </div>
             </div>
-          </ScrollReveal>
-
-          {/* Daily Analytics */}
-          <ScrollReveal delay={450}>
-            <div className="pt-8">
-              <div className="flex items-center gap-2 mb-4">
-                <Calendar size={20} className="text-primary" />
-                <div>
-                  <h2 className="text-lg font-semibold text-foreground">
-                    Daily Analytics
-                  </h2>
-                  <p className="text-xs text-muted-foreground">
-                    {isToday(selectedDate)
-                      ? "Today's trading performance"
-                      : format(selectedDate, "MMMM d, yyyy")}
-                  </p>
-                </div>
+          ) : (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-8 flex flex-col items-center justify-center min-h-[200px] text-muted-foreground text-center">
+                <Map size={32} className="mb-3 opacity-30" />
+                <p className="text-sm font-medium">Account Roadmap</p>
+                <p className="text-xs mt-1 opacity-60">No account connected</p>
               </div>
-              <DailyAnalytics
-                accountId={selectedAccount}
-                selectedDate={selectedDate}
-              />
+              <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-8 flex flex-col items-center justify-center min-h-[200px] text-muted-foreground text-center">
+                <BarChart3 size={32} className="mb-3 opacity-30" />
+                <p className="text-sm font-medium">Trading Analytics</p>
+                <p className="text-xs mt-1 opacity-60">No account connected</p>
+              </div>
             </div>
-          </ScrollReveal>
-        </>
-      )}
+          )}
+        </div>
+      </ScrollReveal>
+
+      {/* Daily Analytics */}
+      <ScrollReveal delay={450}>
+        <div className="pt-8">
+          <div className="flex items-center gap-2 mb-4">
+            <Calendar size={20} className="text-primary" />
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Daily Analytics</h2>
+              <p className="text-xs text-muted-foreground">
+                {isToday(selectedDate)
+                  ? "Today's trading performance"
+                  : format(selectedDate, "MMMM d, yyyy")}
+              </p>
+            </div>
+          </div>
+          {accountData ? (
+            <DailyAnalytics accountId={selectedAccount} selectedDate={selectedDate} />
+          ) : (
+            <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-8 flex flex-col items-center justify-center text-muted-foreground text-center">
+              <Calendar size={32} className="mb-3 opacity-30" />
+              <p className="text-sm font-medium">No trading activity yet</p>
+              <p className="text-xs mt-1 opacity-60">Daily stats will appear here once you start trading</p>
+            </div>
+          )}
+        </div>
+      </ScrollReveal>
     </div>
   );
 };

--- a/src/pages/dashboard/DashboardTrade.tsx
+++ b/src/pages/dashboard/DashboardTrade.tsx
@@ -46,7 +46,7 @@ const DashboardTrade = () => {
           <div>
             <h1 className="text-2xl font-bold text-foreground">Trade</h1>
             <p className="text-muted-foreground mt-1">
-              Live trading via Volumetrica, embedded right here.
+              Live trading via DeepCharts, embedded right here.
             </p>
           </div>
           <div className="flex items-center gap-3">
@@ -100,7 +100,7 @@ const DashboardTrade = () => {
             </p>
             <p className="text-sm text-muted-foreground mt-1">
               {iframeQ.error?.message ??
-                'Try the "Open Platform" button to launch in a new tab.'}
+                'Try the "DeepCharts" button to launch in a new tab.'}
             </p>
           </div>
         </div>
@@ -117,7 +117,7 @@ const DashboardTrade = () => {
           />
           <div className="flex items-center justify-end gap-2 p-2 border-t border-border/30 text-xs text-muted-foreground">
             <ExternalLink size={12} />
-            <span>Embedded via Volumetrica</span>
+            <span>Embedded via DeepCharts</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- **DeepCharts button** — Trade page "Open Platform" renamed to "DeepCharts" with logo; all Volumetrica references updated
- **Purchase flow cleanup** — `BuyChallengeButton` now routes to `/pricing` instead of opening a checkout modal; Dynasty/Instant Funding plan removed (only Standard, Advanced, Builder remain)
- **Sidebar labels** — Desktop sidebar expanded from icon-only (64px) to always-visible icon + label (208px); Pricing external link and Home link added
- **Accounts page** — Restructured into separate Active Accounts and Inactive Accounts sections, each with clean empty states; "New Challenge" → `/pricing` in top-right header
- **Dashboard home** — Full widget structure always visible (metrics, chart, performance overview, daily analytics) with zero/empty states when no accounts exist; "New Challenge" button always in top-right
- **Affiliate modal parity** — Both "Apply to Become an Affiliate" buttons on the public `/affiliates` page now open the same `AffiliateRegistrationModal` used on the dashboard

## Changes

| File | Change |
|---|---|
| `OpenPlatformButton.tsx` | "Open Platform" → "DeepCharts" + logo |
| `BuyChallengeButton.tsx` | Replaced checkout modal with `/pricing` link; removed Dynasty plan |
| `DashboardSidebar.tsx` | Always-visible labels, wider layout, Pricing + Home links |
| `DashboardAccounts.tsx` | Active/Inactive split sections, "New Challenge" header button |
| `DashboardHome.tsx` | Show full dashboard with empty states when no accounts |
| `DashboardTrade.tsx` | Updated subtitle + iframe footer to reference DeepCharts |
| `Affiliates.tsx` | "Apply to Become an Affiliate" opens `AffiliateRegistrationModal` |

## Test plan

- [ ] Trade page top-right shows "DeepCharts" with logo; clicking still launches platform SSO
- [ ] All "New Challenge" / "Buy Challenge" buttons in dashboard navigate to `/pricing` (no modal opens)
- [ ] Dashboard sidebar on desktop shows labels next to every icon; Pricing and Home links present
- [ ] Accounts page shows Active and Inactive sections; both show "No accounts yet" empty states when empty
- [ ] Dashboard home shows full widget layout with $0 / empty states when user has no accounts; "New Challenge" top-right visible
- [ ] Public `/affiliates` page "Apply to Become an Affiliate" opens the registration modal (not support page)

https://claude.ai/code/session_01Tt4BtuhMniEPMijEcwdE1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt4BtuhMniEPMijEcwdE1m)_