### PR TITLE
feat(auth): forgot-password and reset-password pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ const Support = lazy(() => import("./pages/Support"));
 const Legal = lazy(() => import("./pages/Legal"));
 const Login = lazy(() => import("./pages/Login"));
 const Register = lazy(() => import("./pages/Register"));
+const ForgotPassword = lazy(() => import("./pages/ForgotPassword"));
+const ResetPassword = lazy(() => import("./pages/ResetPassword"));
 const About = lazy(() => import("./pages/About"));
 const Payouts = lazy(() => import("./pages/Payouts"));
 const Affiliates = lazy(() => import("./pages/Affiliates"));
@@ -81,6 +83,8 @@ export const AppRoutes = () => (
     <Route path="/legal" element={<LazyRoute><Legal /></LazyRoute>} />
     <Route path="/login" element={<LazyRoute><Login /></LazyRoute>} />
     <Route path="/register" element={<LazyRoute><Register /></LazyRoute>} />
+    <Route path="/forgot-password" element={<LazyRoute><ForgotPassword /></LazyRoute>} />
+    <Route path="/reset-password" element={<LazyRoute><ResetPassword /></LazyRoute>} />
     <Route path="/about" element={<LazyRoute><About /></LazyRoute>} />
     <Route path="/payouts" element={<LazyRoute><Payouts /></LazyRoute>} />
     <Route path="/affiliates" element={<LazyRoute><Affiliates /></LazyRoute>} />

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import Layout from "@/components/layout/Layout";
+import PageMeta from "@/components/seo/PageMeta";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Mail, CheckCircle2 } from "lucide-react";
+import { toast } from "sonner";
+import { authApi } from "@/services/auth";
+import { ApiError } from "@/types/api";
+import ScrollReveal from "@/components/ui/ScrollReveal";
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      await authApi.requestPasswordReset(email);
+      // Backend deliberately returns the same success shape whether the email
+      // exists or not — never differentiate on the client either.
+      setIsSubmitted(true);
+    } catch (error) {
+      if (error instanceof ApiError && error.isRateLimited) {
+        toast.error("Too many requests. Please try again in a few minutes.");
+      } else if (error instanceof ApiError) {
+        toast.error(error.message);
+      } else {
+        toast.error("Something went wrong. Please try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Layout>
+      <PageMeta
+        title="Forgot Password"
+        description="Reset your Dynasty Futures account password. We'll email you a secure link to set a new password."
+        path="/forgot-password"
+        noIndex
+      />
+      <div className="page-transition py-12 md:py-20 min-h-[80vh] flex items-center">
+        <div className="container mx-auto px-4">
+          <div className="max-w-md mx-auto">
+            <ScrollReveal className="text-center mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold mb-2">
+                <span className="text-gradient">Forgot Password</span>
+              </h1>
+              <p className="text-muted-foreground">
+                {isSubmitted
+                  ? "Check your inbox for next steps"
+                  : "Enter your email and we'll send you a reset link"}
+              </p>
+            </ScrollReveal>
+
+            <ScrollReveal delay={150}>
+              <div className="bg-gradient-card rounded-3xl border border-border/50 p-8 relative overflow-hidden">
+                <div className="absolute -top-20 -right-20 w-40 h-40 bg-primary/5 rounded-full blur-3xl pointer-events-none" />
+                <div className="absolute -bottom-10 -left-10 w-32 h-32 bg-gold-dark/5 rounded-full blur-2xl pointer-events-none" />
+
+                {isSubmitted ? (
+                  <div className="text-center space-y-4 py-4">
+                    <div className="flex justify-center">
+                      <CheckCircle2 className="w-16 h-16 text-primary" />
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      If an account exists for{" "}
+                      <span className="text-foreground font-medium">{email}</span>,
+                      you'll receive a password reset link shortly. The link expires
+                      in 60 minutes.
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Didn't get it? Check your spam folder, or try again in a few
+                      minutes.
+                    </p>
+                    <div className="pt-4">
+                      <Link
+                        to="/login"
+                        className="text-primary hover:text-gold-light font-medium transition-colors text-sm"
+                      >
+                        Back to sign in
+                      </Link>
+                    </div>
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit} className="space-y-5">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="email"
+                        className="form-label-glow text-sm font-medium"
+                      >
+                        Email
+                      </Label>
+                      <div className="form-input-wrapper">
+                        <Input
+                          id="email"
+                          type="email"
+                          placeholder="your@email.com"
+                          value={email}
+                          onChange={(e) => setEmail(e.target.value)}
+                          required
+                          disabled={isSubmitting}
+                          className="bg-muted/30 border-border/50"
+                        />
+                      </div>
+                    </div>
+
+                    <Button
+                      type="submit"
+                      size="lg"
+                      variant="gradient"
+                      disabled={isSubmitting}
+                      className="w-full btn-shimmer"
+                    >
+                      <Mail className="w-4 h-4 mr-2" />
+                      {isSubmitting ? "Sending..." : "Send Reset Link"}
+                    </Button>
+
+                    <div className="text-center">
+                      <Link
+                        to="/login"
+                        className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        Back to sign in
+                      </Link>
+                    </div>
+                  </form>
+                )}
+              </div>
+            </ScrollReveal>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -179,9 +179,12 @@ const Login = () => {
                       />
                       <span className="text-muted-foreground group-hover:text-foreground transition-colors">Remember me</span>
                     </label>
-                    <a href="#" className="text-primary hover:text-gold-light transition-colors">
+                    <Link
+                      to="/forgot-password"
+                      className="text-primary hover:text-gold-light transition-colors"
+                    >
                       Forgot password?
-                    </a>
+                    </Link>
                   </div>
 
                   <Button

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import Layout from "@/components/layout/Layout";
+import PageMeta from "@/components/seo/PageMeta";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Eye, EyeOff, KeyRound } from "lucide-react";
+import { toast } from "sonner";
+import { authApi } from "@/services/auth";
+import { ApiError } from "@/types/api";
+import ScrollReveal from "@/components/ui/ScrollReveal";
+
+const ResetPassword = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    password: "",
+    confirmPassword: "",
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!token) {
+      toast.error("Missing reset token. Request a new link from the forgot-password page.");
+      return;
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      toast.error("Passwords do not match");
+      return;
+    }
+
+    if (formData.password.length < 8) {
+      toast.error("Password must be at least 8 characters");
+      return;
+    }
+
+    if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(formData.password)) {
+      toast.error(
+        "Password must contain at least one uppercase letter, one lowercase letter, and one digit"
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await authApi.resetPassword(token, formData.password);
+      toast.success("Password reset successful. Please sign in with your new password.");
+      navigate("/login", { replace: true });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        toast.error(error.message);
+      } else {
+        toast.error("Something went wrong. Please try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // If we landed here without a token, surface that immediately rather than
+  // letting the user fill out the form and get an error on submit.
+  if (!token) {
+    return (
+      <Layout>
+        <PageMeta title="Reset Password" path="/reset-password" noIndex />
+        <div className="page-transition py-12 md:py-20 min-h-[80vh] flex items-center">
+          <div className="container mx-auto px-4">
+            <div className="max-w-md mx-auto text-center">
+              <h1 className="font-display text-3xl md:text-4xl font-bold mb-4">
+                <span className="text-gradient">Invalid Link</span>
+              </h1>
+              <p className="text-muted-foreground mb-6">
+                This password reset link is missing a token. Request a new one to continue.
+              </p>
+              <Link
+                to="/forgot-password"
+                className="text-primary hover:text-gold-light font-medium transition-colors"
+              >
+                Request a new link
+              </Link>
+            </div>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <PageMeta
+        title="Reset Password"
+        description="Set a new password for your Dynasty Futures account."
+        path="/reset-password"
+        noIndex
+      />
+      <div className="page-transition py-12 md:py-20 min-h-[80vh] flex items-center">
+        <div className="container mx-auto px-4">
+          <div className="max-w-md mx-auto">
+            <ScrollReveal className="text-center mb-8">
+              <h1 className="font-display text-3xl md:text-4xl font-bold mb-2">
+                <span className="text-gradient">Reset Password</span>
+              </h1>
+              <p className="text-muted-foreground">
+                Choose a strong new password for your account
+              </p>
+            </ScrollReveal>
+
+            <ScrollReveal delay={150}>
+              <div className="bg-gradient-card rounded-3xl border border-border/50 p-8 relative overflow-hidden">
+                <div className="absolute -top-20 -right-20 w-40 h-40 bg-primary/5 rounded-full blur-3xl pointer-events-none" />
+                <div className="absolute -bottom-10 -left-10 w-32 h-32 bg-gold-dark/5 rounded-full blur-2xl pointer-events-none" />
+
+                <form onSubmit={handleSubmit} className="space-y-5">
+                  <div className="space-y-2">
+                    <Label htmlFor="password" className="form-label-glow text-sm font-medium">
+                      New Password
+                    </Label>
+                    <div className="relative form-input-wrapper">
+                      <Input
+                        id="password"
+                        type={showPassword ? "text" : "password"}
+                        placeholder="••••••••"
+                        value={formData.password}
+                        onChange={(e) =>
+                          setFormData({ ...formData, password: e.target.value })
+                        }
+                        required
+                        disabled={isSubmitting}
+                        className="bg-muted/30 border-border/50 pr-10"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors z-10"
+                      >
+                        {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+                      </button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      At least 8 characters with uppercase, lowercase, and a digit
+                    </p>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="confirmPassword"
+                      className="form-label-glow text-sm font-medium"
+                    >
+                      Confirm Password
+                    </Label>
+                    <div className="relative form-input-wrapper">
+                      <Input
+                        id="confirmPassword"
+                        type={showConfirm ? "text" : "password"}
+                        placeholder="••••••••"
+                        value={formData.confirmPassword}
+                        onChange={(e) =>
+                          setFormData({ ...formData, confirmPassword: e.target.value })
+                        }
+                        required
+                        disabled={isSubmitting}
+                        className="bg-muted/30 border-border/50 pr-10"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setShowConfirm(!showConfirm)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors z-10"
+                      >
+                        {showConfirm ? <EyeOff size={18} /> : <Eye size={18} />}
+                      </button>
+                    </div>
+                  </div>
+
+                  <Button
+                    type="submit"
+                    size="lg"
+                    variant="gradient"
+                    disabled={isSubmitting}
+                    className="w-full btn-shimmer"
+                  >
+                    <KeyRound className="w-4 h-4 mr-2" />
+                    {isSubmitting ? "Resetting..." : "Reset Password"}
+                  </Button>
+
+                  <div className="text-center">
+                    <Link
+                      to="/login"
+                      className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      Back to sign in
+                    </Link>
+                  </div>
+                </form>
+              </div>
+            </ScrollReveal>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default ResetPassword;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -52,6 +52,11 @@ export interface LogoutResponse {
   message: string;
 }
 
+export interface SimpleSuccessResponse {
+  success: true;
+  message: string;
+}
+
 // ---------------------------------------------------------------------------
 // API methods
 // ---------------------------------------------------------------------------
@@ -95,4 +100,21 @@ export const authApi = {
    * Fetch the currently authenticated user's profile.
    */
   getMe: () => apiClient.get<MeResponse>('/auth/me'),
+
+  /**
+   * Initiate a password reset. Always resolves successfully regardless of
+   * whether the email is on file (the backend uses a constant response shape
+   * to prevent email enumeration).
+   */
+  requestPasswordReset: (email: string) =>
+    apiClient.post<SimpleSuccessResponse>('/auth/password/forgot', { email }),
+
+  /**
+   * Complete a password reset using the token from the email link.
+   */
+  resetPassword: (token: string, newPassword: string) =>
+    apiClient.post<SimpleSuccessResponse>('/auth/password/reset', {
+      token,
+      newPassword,
+    }),
 } as const;


### PR DESCRIPTION
@
## Summary

Adds the front-end for the forgot-password flow: a request page and a token-driven reset page, wired to the new backend endpoints. Pairs with DF-Backend #6.

## What changed

- **`services/auth.ts`:** `authApi.requestPasswordReset(email)` → `POST /auth/password/forgot`, and `authApi.resetPassword(token, newPassword)` → `POST /auth/password/reset`.
- **`pages/ForgotPassword.tsx` (new):** single email input → generic success screen. Never differentiates whether the email is on file (mirrors the backend no-enumeration design). Handles rate-limit errors.
- **`pages/ResetPassword.tsx` (new):** reads `?token=` from the URL, password + confirm with the same complexity rules as Register, redirects to `/login` on success, shows an "Invalid Link" screen when the token is missing.
- **`App.tsx`:** lazy public routes `/forgot-password` and `/reset-password`.
- **`Login.tsx`:** the placeholder "Forgot password?" link now routes to `/forgot-password`.

## Testing

- `npm run build` — clean (11 prerendered routes)
- `npm run lint` — no new errors/warnings (baseline of 6/23 unchanged, all pre-existing in unrelated files)
- E2E verified locally against the backend reset endpoints.

## Local testing note

Set backend `FRONTEND_URL=http://localhost:8080` so the emailed reset link points at the local front-end.
@