### PR TITLE
feat(affiliates): submit affiliate registration to the backend

### DIFF
--- a/src/components/dashboard/AffiliateRegistrationModal.tsx
+++ b/src/components/dashboard/AffiliateRegistrationModal.tsx
@@ -14,8 +14,11 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { affiliateService } from "@/services/affiliates";
+import { ApiError } from "@/types/api";
 
 interface FormData {
   websiteUrl: string;
@@ -203,34 +206,42 @@ const AffiliateRegistrationModal = ({ open, onOpenChange }: AffiliateRegistratio
     if (!validateStep(3)) return;
     setIsSubmitting(true);
 
-    // TODO: Replace with real API endpoint when affiliate backend is ready.
-    // POST /v1/affiliates/apply — userId is extracted server-side from the auth token.
-    const affiliateApplication = {
-      websiteUrl: form.websiteUrl,
-      youtubeUrl: form.youtubeUrl,
-      xUrl: form.xUrl,
-      instagramUrl: form.instagramUrl,
-      facebookUrl: form.facebookUrl,
-      telegramUrl: form.telegramUrl,
-      discordUrl: form.discordUrl,
-      isFundedTrader: form.isFundedTrader === "yes",
-      hasActiveDynastyAccount: form.hasActiveDynastyAccount === "yes",
-      promotionPlan: form.promotionPlan,
-      primaryTrafficMethod: form.primaryTrafficMethod,
-      createsCustomContent: form.createsCustomContent === "yes",
-      contentUpdateFrequency: form.contentUpdateFrequency,
-      preferredAffiliateCode: form.preferredAffiliateCode,
-      restrictedJurisdictionConfirmation: form.restrictedJurisdictionConfirmation,
-      submittedAt: new Date().toISOString(),
-      status: "pending" as const,
+    // Only send URL fields that were actually filled in — the backend validates
+    // each as a URL and rejects malformed values.
+    const trimmedUrl = (v: string) => {
+      const trimmed = v.trim();
+      return trimmed ? trimmed : undefined;
     };
 
-    console.log("Affiliate application:", affiliateApplication);
-    // Placeholder: remove this delay when connecting to real endpoint
-    await new Promise<void>(resolve => setTimeout(resolve, 800));
+    try {
+      await affiliateService.apply({
+        websiteUrl: trimmedUrl(form.websiteUrl),
+        youtubeUrl: trimmedUrl(form.youtubeUrl),
+        xUrl: trimmedUrl(form.xUrl),
+        instagramUrl: trimmedUrl(form.instagramUrl),
+        facebookUrl: trimmedUrl(form.facebookUrl),
+        telegramUrl: trimmedUrl(form.telegramUrl),
+        discordUrl: trimmedUrl(form.discordUrl),
+        isFundedTrader: form.isFundedTrader === "yes",
+        hasActiveDynastyAccount: form.hasActiveDynastyAccount === "yes",
+        promotionPlan: form.promotionPlan,
+        primaryTrafficMethod: form.primaryTrafficMethod,
+        createsCustomContent: form.createsCustomContent === "yes",
+        contentUpdateFrequency: form.contentUpdateFrequency,
+        preferredAffiliateCode: form.preferredAffiliateCode,
+        restrictedJurisdictionConfirmation: form.restrictedJurisdictionConfirmation,
+      });
 
-    setIsSubmitting(false);
-    setSubmitted(true);
+      setSubmitted(true);
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Something went wrong submitting your application. Please try again.";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleClose = (isOpen: boolean) => {

--- a/src/services/affiliates.ts
+++ b/src/services/affiliates.ts
@@ -1,0 +1,47 @@
+// =============================================================================
+// Dynasty Futures - Affiliate Service
+// =============================================================================
+// Maps to the backend's /v1/affiliates endpoints.
+//
+// Usage:
+//   import { affiliateService } from '@/services/affiliates';
+//   await affiliateService.apply({ ... });
+// =============================================================================
+
+import { apiClient } from '@/services/api';
+
+export interface AffiliateApplicationInput {
+  websiteUrl?: string;
+  youtubeUrl?: string;
+  xUrl?: string;
+  instagramUrl?: string;
+  facebookUrl?: string;
+  telegramUrl?: string;
+  discordUrl?: string;
+  isFundedTrader: boolean;
+  hasActiveDynastyAccount: boolean;
+  promotionPlan: string;
+  primaryTrafficMethod: string;
+  createsCustomContent: boolean;
+  contentUpdateFrequency: string;
+  preferredAffiliateCode: string;
+  restrictedJurisdictionConfirmation: boolean;
+}
+
+export interface AffiliateApplicationResponse {
+  success: true;
+  data: {
+    id: string;
+    status: 'PENDING' | 'APPROVED' | 'REJECTED';
+  };
+  message?: string;
+}
+
+export const affiliateService = {
+  /**
+   * Submit an affiliate program application.
+   * POST /v1/affiliates/apply
+   */
+  apply: (data: AffiliateApplicationInput): Promise<AffiliateApplicationResponse> =>
+    apiClient.post<AffiliateApplicationResponse>('/affiliates/apply', data),
+} as const;


### PR DESCRIPTION
## What

Wires the affiliate registration modal's submit button to actually send the application. Previously `handleSubmit` only `console.log`'d the form behind an 800ms fake delay, then showed the success screen — so no application ever left the browser.

## How

- New `src/services/affiliates.ts` — `affiliateService.apply()` → `POST /v1/affiliates/apply`.
- `AffiliateRegistrationModal.tsx` — `handleSubmit` now calls the API in `try/catch/finally`: only sends trimmed/non-empty URL fields, shows the success screen on a real 201, surfaces failures with a `toast.error`, and always clears the submitting state. Removed the placeholder + TODO.

## Testing

- ESLint clean on the changed files (repo baseline of pre-existing errors/warnings unchanged)
- `npm run build` clean, 11 routes prerendered

## Companion

Backend endpoint: DF-Backend #8 (`affiliateApplyEmail`). The endpoint must be deployed for submissions to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
