### PR TITLE
feat(dashboard): per-page browser tab titles

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,10 +1,41 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import DashboardSidebar from './DashboardSidebar';
 import DashboardMobileNav from './DashboardMobileNav';
 
+const SITE_NAME = 'Dynasty Futures';
+
+// Maps each dashboard route to the page name shown in the browser tab.
+const DASHBOARD_TITLES: Record<string, string> = {
+  '/dashboard': 'Dashboard',
+  '/dashboard/accounts': 'Accounts',
+  '/dashboard/trade': 'Trade',
+  '/dashboard/billing': 'Billing',
+  '/dashboard/payouts': 'Payouts',
+  '/dashboard/affiliate': 'Affiliate',
+  '/dashboard/profile': 'Profile',
+  '/dashboard/achievements': 'Achievements',
+  '/dashboard/help': 'Help Center',
+};
+
+const getDashboardTitle = (pathname: string): string => {
+  // Journal is a dynamic route (/dashboard/journal/:date), so match by prefix.
+  if (pathname.startsWith('/dashboard/journal')) return 'Journal';
+  return DASHBOARD_TITLES[pathname] ?? 'Dashboard';
+};
+
 const DashboardLayout = () => {
+  const { pathname } = useLocation();
+  const pageTitle = `${getDashboardTitle(pathname)} | ${SITE_NAME}`;
+
   return (
     <div className="min-h-screen bg-background">
+      <Helmet>
+        <title>{pageTitle}</title>
+        {/* Private area — keep dashboard out of search indexes. */}
+        <meta name="robots" content="noindex,nofollow" />
+      </Helmet>
+
       {/* Mobile Navigation */}
       <DashboardMobileNav />
       


### PR DESCRIPTION
## What
Dashboard pages all share `DashboardLayout` and never set a document title, so while navigating the authenticated area the Chrome tab fell back to the static default (`Dynasty Futures`) or whatever the previously-visited page left behind.

This derives the tab title from the current route in `DashboardLayout`, so each dashboard page now reads `<Page> | Dynasty Futures`:

| Route | Tab title |
|---|---|
| `/dashboard` | Dashboard \| Dynasty Futures |
| `/dashboard/accounts` | Accounts \| Dynasty Futures |
| `/dashboard/trade` | Trade \| Dynasty Futures |
| `/dashboard/billing` | Billing \| Dynasty Futures |
| `/dashboard/payouts` | Payouts \| Dynasty Futures |
| `/dashboard/affiliate` | Affiliate \| Dynasty Futures |
| `/dashboard/profile` | Profile \| Dynasty Futures |
| `/dashboard/achievements` | Achievements \| Dynasty Futures |
| `/dashboard/help` | Help Center \| Dynasty Futures |
| `/dashboard/journal/:date` | Journal \| Dynasty Futures |

## Why one place instead of 10
All dashboard pages share `DashboardLayout`, so a single `<Helmet>` keyed off `useLocation()` covers every current page (and any future one falls back to `Dashboard | Dynasty Futures`) without pasting `PageMeta` into all 10 page components. Page names match the sidebar labels exactly. The separator stays `|` to match the existing public-page titles.

## Notes
- Also added a `noindex,nofollow` robots meta to the dashboard — good hygiene for a private, auth-gated area (it had none before).
- Public pages and the SEO-rich home title are untouched.

## Testing
- `npm run build` passes; all 11 public routes still prerender.