### PR TITLE
Replace Achievements with Awards tab in dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ const DashboardBilling = lazy(() => import("./pages/dashboard/DashboardBilling")
 const DashboardPayouts = lazy(() => import("./pages/dashboard/DashboardPayouts"));
 const DashboardProfile = lazy(() => import("./pages/dashboard/DashboardProfile"));
 const DashboardAchievements = lazy(() => import("./pages/dashboard/DashboardAchievements"));
+const DashboardAwards = lazy(() => import("./pages/dashboard/DashboardAwards"));
 const DashboardHelp = lazy(() => import("./pages/dashboard/DashboardHelp"));
 const DashboardAffiliate = lazy(() => import("./pages/dashboard/DashboardAffiliate"));
 const DashboardJournal = lazy(() => import("./pages/dashboard/DashboardJournal"));
@@ -104,6 +105,7 @@ export const AppRoutes = () => (
       <Route path="affiliate" element={<LazyRoute><DashboardAffiliate /></LazyRoute>} />
       <Route path="profile" element={<LazyRoute><DashboardProfile /></LazyRoute>} />
       <Route path="achievements" element={<LazyRoute><DashboardAchievements /></LazyRoute>} />
+      <Route path="awards" element={<LazyRoute><DashboardAwards /></LazyRoute>} />
       <Route path="help" element={<LazyRoute><DashboardHelp /></LazyRoute>} />
       <Route path="journal/:date" element={<LazyRoute><DashboardJournal /></LazyRoute>} />
       <Route path="trade" element={<LazyRoute><DashboardTrade /></LazyRoute>} />

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -15,6 +15,7 @@ const DASHBOARD_TITLES: Record<string, string> = {
   '/dashboard/affiliate': 'Affiliate',
   '/dashboard/profile': 'Profile',
   '/dashboard/achievements': 'Achievements',
+  '/dashboard/awards': 'Awards',
   '/dashboard/help': 'Help Center',
 };
 

--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -15,7 +15,7 @@ const sidebarLinks = [
   { name: 'Payouts', path: '/dashboard/payouts', icon: Banknote },
   { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
   { name: 'Profile', path: '/dashboard/profile', icon: User },
-  { name: 'Achievements', path: '/dashboard/achievements', icon: Trophy },
+  { name: 'Awards', path: '/dashboard/awards', icon: Trophy },
   { name: 'Help Center', path: '/dashboard/help', icon: HelpCircle },
 ];
 

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -24,7 +24,7 @@ const sidebarLinks = [
   { name: 'Payouts', path: '/dashboard/payouts', icon: ArrowDownToLine },
   { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
   { name: 'Profile', path: '/dashboard/profile', icon: User },
-  { name: 'Achievements', path: '/dashboard/achievements', icon: Award },
+  { name: 'Awards', path: '/dashboard/awards', icon: Award },
   { name: 'Help Center', path: '/dashboard/help', icon: Headphones },
 ];
 

--- a/src/pages/dashboard/DashboardAwards.tsx
+++ b/src/pages/dashboard/DashboardAwards.tsx
@@ -1,0 +1,101 @@
+import { useQuery } from '@tanstack/react-query';
+import { Download, Eye, FileText } from 'lucide-react';
+import { apiClient } from '@/services/api';
+import type { ApiResponse } from '@/types/api';
+
+interface AwardDocument {
+  title: string;
+  viewUrl?: string;
+  downloadUrl?: string;
+}
+
+const fetchAwards = async (): Promise<AwardDocument[]> => {
+  const res = await apiClient.get<ApiResponse<AwardDocument[]>>('/v1/awards');
+  return res.data;
+};
+
+const DashboardAwards = () => {
+  const { data: awards, isLoading, isError } = useQuery({
+    queryKey: ['awards'],
+    queryFn: fetchAwards,
+  });
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Awards</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Your funded and payout certificates issued by Dynasty Futures.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="glass-card rounded-xl p-4 animate-pulse">
+              <div className="h-4 bg-muted/40 rounded w-1/3" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="glass-card rounded-xl p-6 text-center">
+          <p className="text-sm text-muted-foreground">Unable to load awards. Please try again later.</p>
+        </div>
+      )}
+
+      {!isLoading && !isError && awards && awards.length === 0 && (
+        <div className="glass-card rounded-xl p-10 flex flex-col items-center gap-3 text-center">
+          <FileText size={36} className="text-muted-foreground/50" />
+          <p className="text-base font-medium text-foreground">No awards available yet.</p>
+          <p className="text-sm text-muted-foreground max-w-sm">
+            Your funded and payout certificates will appear here once they are issued.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && awards && awards.length > 0 && (
+        <div className="space-y-3">
+          {awards.map((award, idx) => (
+            <div
+              key={idx}
+              className="glass-card rounded-xl px-5 py-4 flex items-center justify-between gap-4"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <FileText size={18} className="text-primary shrink-0" />
+                <span className="text-sm font-medium text-foreground truncate">{award.title}</span>
+              </div>
+
+              <div className="flex items-center gap-2 shrink-0">
+                {award.viewUrl && (
+                  <a
+                    href={award.viewUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border/50 text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+                  >
+                    <Eye size={13} />
+                    View
+                  </a>
+                )}
+                {award.downloadUrl && (
+                  <a
+                    href={award.downloadUrl}
+                    download
+                    className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary/10 border border-primary/20 text-primary hover:bg-primary/20 transition-colors"
+                  >
+                    <Download size={13} />
+                    Download
+                  </a>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardAwards;


### PR DESCRIPTION
## Summary

- Hides the Achievements tab from the dashboard sidebar (code is preserved and still accessible at `/dashboard/achievements` — not deleted)
- Adds a new **Awards** tab to both the desktop sidebar and mobile nav
- Creates `DashboardAwards` page that fetches award/certificate documents from the backend (`GET /v1/awards`) and displays them as simple document rows with **View** and **Download** buttons
- Shows a clean empty state ("No awards available yet.") when no documents are returned

## What was NOT built

Per requirements: no certificate generation logic, no mock data, no achievement badges, no rarity labels, no progress tracking, no payout/account size fields.

## Data shape expected from backend

```ts
// GET /v1/awards → ApiResponse<AwardDocument[]>
interface AwardDocument {
  title: string;
  viewUrl?: string;
  downloadUrl?: string;
}
```

## Test plan

- [ ] Visit `/dashboard` — sidebar shows **Awards**, not Achievements
- [ ] Visit `/dashboard/awards` — page renders (empty state if no backend data)
- [ ] Confirm `/dashboard/achievements` route still works (code preserved)
- [ ] Mobile nav shows **Awards** tab in the slide-out menu
- [ ] When backend returns documents, each row shows title + View/Download buttons as available

https://claude.ai/code/session_018WkrMuaPttb2PCrLLjJRex

---
_Generated by [Claude Code](https://claude.ai/code/session_018WkrMuaPttb2PCrLLjJRex)_