### PR TITLE
Drive DailyAnalytics from real trades

### DIFF
--- a/src/components/dashboard/DailyAnalytics.tsx
+++ b/src/components/dashboard/DailyAnalytics.tsx
@@ -1,49 +1,67 @@
 import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { useAccountView } from '@/hooks/useAccountView';
+import { useAccountTrades } from '@/hooks/useTrading';
 import { TrendingUp, TrendingDown, Target, Award, ShieldAlert, Calendar } from 'lucide-react';
-import { format, differenceInDays, isToday as isDateToday } from 'date-fns';
+import { format, differenceInDays, isToday as isDateToday, isSameDay } from 'date-fns';
 
 interface DailyAnalyticsProps {
   accountId: string;
   selectedDate?: Date;
 }
 
+interface TradeHighlight {
+  amount: number;
+  instrument: string;
+}
+
 const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalyticsProps) => {
   const { data: account } = useAccountView(accountId);
+  // Shares the trades query with useAccountView (same React Query key — no extra fetch).
+  const tradesQ = useAccountTrades(accountId);
+  const trades = useMemo(() => tradesQ.data?.data ?? [], [tradesQ.data]);
   const dailyPnL = useMemo(() => account?.dailyPnL ?? [], [account]);
 
   // Calculate the P&L for the selected date
-  const { dayPnL, hasTrades } = useMemo(() => {
+  const dayPnL = useMemo(() => {
     const today = new Date();
     const daysAgo = differenceInDays(today, selectedDate);
     const pnlIndex = dailyPnL.length - 1 - daysAgo;
 
     if (pnlIndex >= 0 && pnlIndex < dailyPnL.length) {
-      const pnl = dailyPnL[pnlIndex];
-      return { dayPnL: pnl, hasTrades: pnl !== 0 };
+      return dailyPnL[pnlIndex];
     }
-    return { dayPnL: 0, hasTrades: false };
+    return 0;
   }, [dailyPnL, selectedDate]);
-  
-  // Generate consistent mock data based on the selected date (seed with date)
-  const mockData = useMemo(() => {
-    const seed = selectedDate.getTime();
-    const seededRandom = (offset: number) => {
-      const x = Math.sin(seed + offset) * 10000;
-      return x - Math.floor(x);
-    };
-    
-    return {
-      tradesCount: Math.floor(seededRandom(1) * 8) + 2,
-      winRate: Math.floor(seededRandom(2) * 30) + 55,
-      bestTrade: Math.abs(dayPnL * 0.6) + Math.floor(seededRandom(3) * 150) + 100,
-      worstTrade: Math.abs(dayPnL * 0.3) + Math.floor(seededRandom(4) * 80) + 50,
-      bestInstrument: ['ES', 'NQ', 'CL', 'GC'][Math.floor(seededRandom(5) * 4)],
-      worstInstrument: ['ES', 'NQ', 'CL', 'GC'][Math.floor(seededRandom(6) * 4)],
-    };
-  }, [selectedDate, dayPnL]);
-  
+
+  // Derive trade stats for the selected day from real closed trades, attributing
+  // each trade to the day it was realized (exitTime).
+  const daily = useMemo(() => {
+    const dayTrades = trades.filter(
+      (t) =>
+        t.exitTime !== null &&
+        t.realizedPnl !== null &&
+        isSameDay(new Date(t.exitTime), selectedDate),
+    );
+
+    const pnls = dayTrades.map((t) => Number(t.realizedPnl));
+    const tradesCount = dayTrades.length;
+    const wins = pnls.filter((p) => p > 0).length;
+    const winRate = tradesCount > 0 ? Math.round((wins / tradesCount) * 100) : 0;
+
+    let best: TradeHighlight | null = null;
+    let worst: TradeHighlight | null = null;
+    for (const t of dayTrades) {
+      const amount = Number(t.realizedPnl);
+      if (best === null || amount > best.amount) best = { amount, instrument: t.symbol };
+      if (worst === null || amount < worst.amount) worst = { amount, instrument: t.symbol };
+    }
+
+    return { tradesCount, winRate, best, worst };
+  }, [trades, selectedDate]);
+
+  const hasActivity = daily.tradesCount > 0 || dayPnL !== 0;
+
   const dailyDrawdownUsed = account
     ? (Math.abs(Math.min(0, dayPnL)) / Math.max(account.dailyLossLimit, 1)) * 100
     : 0;
@@ -61,7 +79,7 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
     return value < 0 ? `-${formatted}` : formatted;
   };
 
-  if (!hasTrades) {
+  if (!hasActivity) {
     return (
       <div className="flex flex-col items-center justify-center p-8 rounded-xl bg-muted/5 border border-border/20">
         <Calendar size={28} className="text-muted-foreground mb-3" />
@@ -101,20 +119,20 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
           <Target size={14} className="text-primary" />
           <span className="text-xs text-muted-foreground">{isDateToday(selectedDate) ? "Trades Today" : "Trades"}</span>
         </div>
-        <span className="text-lg font-bold text-foreground">{mockData.tradesCount}</span>
+        <span className="text-lg font-bold text-foreground">{daily.tradesCount}</span>
       </div>
 
       {/* Win Rate */}
       <div className="p-3 rounded-xl bg-muted/10 border border-border/20 hover:border-primary/30 transition-all duration-300 group">
         <div className="flex items-center gap-2 mb-1.5">
-          <Award size={14} className={cn(mockData.winRate >= 60 ? "text-primary" : "text-amber-500")} />
+          <Award size={14} className={cn(daily.winRate >= 60 ? "text-primary" : "text-amber-500")} />
           <span className="text-xs text-muted-foreground">Win Rate</span>
         </div>
         <span className={cn(
           "text-lg font-bold",
-          mockData.winRate >= 60 ? "text-primary" : "text-amber-500"
+          daily.winRate >= 60 ? "text-primary" : "text-amber-500"
         )}>
-          {mockData.winRate}%
+          {daily.tradesCount > 0 ? `${daily.winRate}%` : '—'}
         </span>
       </div>
 
@@ -143,8 +161,19 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
           <span className="text-xs text-muted-foreground">Best Trade</span>
         </div>
         <div className="flex items-baseline gap-1.5">
-          <span className="text-lg font-bold text-green-400">+{formatCurrency(mockData.bestTrade)}</span>
-          <span className="text-[10px] text-muted-foreground">({mockData.bestInstrument})</span>
+          {daily.best ? (
+            <>
+              <span className={cn(
+                "text-lg font-bold",
+                daily.best.amount >= 0 ? "text-green-400" : "text-destructive"
+              )}>
+                {formatCurrency(daily.best.amount, true)}
+              </span>
+              <span className="text-[10px] text-muted-foreground">({daily.best.instrument})</span>
+            </>
+          ) : (
+            <span className="text-lg font-bold text-muted-foreground">—</span>
+          )}
         </div>
       </div>
 
@@ -155,8 +184,19 @@ const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalytics
           <span className="text-xs text-muted-foreground">Worst Trade</span>
         </div>
         <div className="flex items-baseline gap-1.5">
-          <span className="text-lg font-bold text-destructive">-{formatCurrency(mockData.worstTrade)}</span>
-          <span className="text-[10px] text-muted-foreground">({mockData.worstInstrument})</span>
+          {daily.worst ? (
+            <>
+              <span className={cn(
+                "text-lg font-bold",
+                daily.worst.amount < 0 ? "text-destructive" : "text-green-400"
+              )}>
+                {formatCurrency(daily.worst.amount, true)}
+              </span>
+              <span className="text-[10px] text-muted-foreground">({daily.worst.instrument})</span>
+            </>
+          ) : (
+            <span className="text-lg font-bold text-muted-foreground">—</span>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

The dashboard's **Daily Analytics** panel rendered date-seeded **mock** values for four of its six tiles — Trades, Win Rate, Best Trade, Worst Trade — so it showed fabricated numbers on the main dashboard. This derives them from the trader's real closed trades.

## Changes

- `components/dashboard/DailyAnalytics.tsx`:
  - Trades count, win rate, and best/worst trade (with instrument) are computed from trades whose `exitTime` falls on the selected day.
  - Trades come from `useAccountTrades` — the **same React Query key** `useAccountView` already uses, so there's no extra network request.
  - Best/worst tiles now show signed amounts with sign-based colors and render `—` when the day has no closed trades.
  - The empty-state gate keys off real activity (trades present or non-zero day P&L) instead of the mock seed.
- Day's P&L and Daily Drawdown tiles were already real — unchanged.

## Testing

- `npm run build` clean (11 routes prerendered), lint clean.

> Populates once an account has synced trade data. No backend change required.
