### PR TITLE
Launch polish: pricing plan cards, About page copy, Cliff Adams quote

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -73,7 +73,7 @@ const About = () => {
                 <span className="text-gradient-animated">Clarity, Discipline, and Opportunity</span>
               </h1>
               <p className="text-lg md:text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-                Dynasty Futures LLC was built to offer something the prop firm
+                Dynasty Futures was built to offer something the prop firm
                 space was missing: fair pricing, higher max loss flexibility,
                 honest payout transparency, and a firm focused on long-term
                 trust.
@@ -267,7 +267,7 @@ const About = () => {
               </div>
               <div className="mt-6 pt-6 border-t border-border/30 flex items-center gap-2 text-xs text-muted-foreground">
                 <Building2 className="w-3.5 h-3.5 flex-shrink-0" />
-                <span>Dynasty Futures LLC, registered in Wyoming</span>
+                <span>Dynasty Futures, registered in Wyoming</span>
               </div>
             </div>
           </ScrollReveal>
@@ -474,6 +474,14 @@ const About = () => {
                       trust the company wants to be known for.
                     </p>
                   </div>
+                  <blockquote className="border-l-2 border-primary pl-6 mb-6">
+                    <p className="text-foreground italic leading-relaxed">
+                      "Markets reward discipline. Businesses reward patience. Long-term success comes from mastering both."
+                    </p>
+                    <footer className="mt-3 text-sm text-muted-foreground font-medium">
+                      — Cliff Adams
+                    </footer>
+                  </blockquote>
                   <a
                     href="https://www.linkedin.com/in/cliff-adams-9b7b1180"
                     target="_blank"

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -436,13 +436,13 @@ const Pricing = () => {
             <section className="mb-20">
               <ScrollReveal className="glass-card-strong rounded-3xl border border-border/50 overflow-hidden p-8 md:p-12">
                 {/* Plan Selector */}
-                <div className="grid grid-cols-3 sm:flex sm:flex-wrap sm:justify-center gap-2 sm:gap-3 mb-6">
+                <div className="grid grid-cols-3 gap-4 sm:gap-6 mb-8">
                   {(Object.keys(planConfig) as PlanKey[]).map((plan) => (
                     <button
                       key={plan}
                       onClick={() => handlePlanChange(plan)}
                       className={cn(
-                        "px-2 py-4 sm:px-8 sm:py-6 rounded-xl font-display font-semibold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col items-center justify-center gap-2 sm:gap-2.5 h-full sm:h-auto min-w-0 sm:min-w-[180px]",
+                        "w-full py-7 sm:py-10 px-3 sm:px-6 rounded-2xl font-display font-semibold text-sm transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary flex flex-col items-center justify-center gap-3 sm:gap-4",
                         selectedPlan === plan
                           ? "bg-gradient-to-r from-gold-dark via-primary to-gold-light text-white border border-primary/60 shadow-lg shadow-primary/20"
                           : "border border-border/50 text-muted-foreground hover:border-primary/40 hover:text-foreground bg-transparent",
@@ -450,9 +450,9 @@ const Pricing = () => {
                     >
                       <PlanImage
                         plan={plan}
-                        size={64}
+                        size={80}
                         className={cn(
-                          "w-8 h-8 sm:w-16 sm:h-16",
+                          "w-12 h-12 sm:w-20 sm:h-20",
                           selectedPlan === plan
                             ? "brightness-0 invert drop-shadow-sm"
                             : undefined,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Pricing page — plan selector cards**: Increased card size, icon size (w-20/h-20 on desktop), and spacing. Switched from flex to a consistent 3-column grid so all three cards are exactly equal width and height. Cards now feel like a premium product-selection experience rather than small buttons.
- **About page — brand name**: Replaced all instances of "Dynasty Futures LLC" with "Dynasty Futures" for a cleaner brand presentation.
- **About page — Cliff Adams quote**: Added missing closing quote beneath Cliff's bio, styled identically to the existing Brock and Zachary quote blocks (gold accent border-left, italic text, attribution footer).

## No logic changes
No pricing data, routing, auth, or API logic was modified.

## Test plan
- [ ] Visit `/pricing` — confirm all three plan cards are visibly larger, equal in size, and icons are bigger
- [ ] Confirm Advanced card is no longer wider than Standard/Builder
- [ ] Visit `/about` — confirm "Dynasty Futures LLC" no longer appears in hero or footer chip
- [ ] Confirm Cliff Adams card now has a quote block matching the style of Brock and Zachary

https://claude.ai/code/session_01Kb5Y61HDu7HVQSJY9AuQx9
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb5Y61HDu7HVQSJY9AuQx9)_