### PR TITLE
Fix founder cards: Brock location → Utah, equalize card dimensions

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -77,10 +77,10 @@ const FounderCard = ({
 }: FounderCardProps) => {
   const [expanded, setExpanded] = useState(false);
   return (
-    <ScrollReveal delay={delay}>
+    <ScrollReveal delay={delay} className="h-full">
       <div className="bg-gradient-card rounded-2xl border border-border/50 flex flex-col h-full overflow-hidden">
         {/* Headshot */}
-        <div className="relative w-full aspect-[3/4] overflow-hidden">
+        <div className="relative w-full h-80 overflow-hidden">
           <img
             src={image}
             alt={name}
@@ -170,7 +170,7 @@ const founders: FounderCardProps[] = [
     name: "Brock Adams",
     title: "Chief Executive Officer",
     badge: "Founder",
-    location: "Texas",
+    location: "Utah",
     preview:
       "Brock focuses on long-term company building, trader experience, and creating a prop firm designed around transparency and sustainability.",
     fullBio: (
@@ -270,7 +270,7 @@ const FoundersSection = () => (
       </p>
     </ScrollReveal>
 
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto items-start">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-5xl mx-auto items-stretch">
       {founders.map((f, i) => (
         <FounderCard key={f.name} {...f} delay={i * 100} />
       ))}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Update Brock Adams' location from **Texas** to **Utah**
- Replace `aspect-[3/4]` image container with a fixed `h-80` height so all three headshots render at identical dimensions
- Switch the founder grid from `items-start` to `items-stretch` so cards grow to the same height
- Add `h-full` to the `ScrollReveal` wrapper so the height propagates through to the card element

## Result

All three founder cards (Brock Adams / Utah, Zachary Perez / Georgia, Cliff Adams / Texas) now have perfectly matched widths, heights, image areas, and bottom alignment regardless of bio preview length.

## Test plan

- [ ] Visit `/about` and confirm all three founder cards are visually identical in size
- [ ] Verify Brock Adams shows **Utah** under his name
- [ ] Verify Zachary Perez shows **Georgia** and Cliff Adams shows **Texas** (unchanged)
- [ ] Expand each bio and confirm cards still align correctly
- [ ] Check on mobile (single column) and tablet (2-column) breakpoints

https://claude.ai/code/session_019Km9kV9gJc8aQujgXhpy19
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Km9kV9gJc8aQujgXhpy19)_