### PR TITLE
Add Trustpilot review CTA to homepage hero

### DIFF
--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -170,6 +170,36 @@ const Hero = () => {
                 </a>
               </Button>
             </div>
+
+            {/* Trustpilot CTA */}
+            <div className="flex justify-center lg:justify-start mt-2 animate-fade-in" style={{ animationDelay: "0.45s" }}>
+              <a
+                href="https://www.trustpilot.com/review/dynastyfuturesdyn.com?_gl=1*r3p7l0*_gcl_au*MTQ4MzEyNDE1Ny4xNzgxMjE1NTEz*_ga*MjAyMTc4MzE1My4xNzgxMjE1NTEz*_ga_11HBWMC274*czE3ODEyNDA4NjIkbzMkZzEkdDE3ODEyNDEzMjIkajYwJGwwJGgw"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group inline-flex items-center gap-2.5 px-4 py-2 rounded-full border border-white/10 bg-white/5 backdrop-blur-sm hover:bg-white/10 hover:border-white/20 transition-all duration-300 hover:shadow-md hover:shadow-black/20"
+              >
+                {/* Trustpilot stars */}
+                <span className="flex items-center gap-0.5">
+                  {[...Array(5)].map((_, i) => (
+                    <span
+                      key={i}
+                      className="inline-flex items-center justify-center w-4 h-4 rounded-sm bg-[#00b67a]"
+                      aria-hidden="true"
+                    >
+                      <svg viewBox="0 0 24 24" fill="white" className="w-2.5 h-2.5">
+                        <path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 17l-6.2 4.3 2.4-7.4L2 9.4h7.6z" />
+                      </svg>
+                    </span>
+                  ))}
+                </span>
+                {/* Trustpilot wordmark */}
+                <span className="text-xs font-semibold text-foreground/80 tracking-tight">Trustpilot</span>
+                <span className="text-xs text-muted-foreground group-hover:text-foreground transition-colors duration-200 whitespace-nowrap">
+                  Review us on Trustpilot
+                </span>
+              </a>
+            </div>
           </div>
 
           {/* Right content - Trading Dashboard Mock */}


### PR DESCRIPTION
## Summary

- Adds a compact Trustpilot review pill element directly below the "View Dynasty Plans" / "Join Our Community" hero buttons
- Includes Trustpilot green star icons, "Trustpilot" wordmark text, and "Review us on Trustpilot" copy
- Links to the Dynasty Futures Trustpilot profile page, opens in a new tab
- No fake ratings, star scores, review counts, or "Excellent" claims — safe wording only

## Design

- Pill/card layout with `backdrop-blur`, subtle border, and hover state
- Trustpilot green (`#00b67a`) star blocks to maintain brand recognition
- Matches the site's dark theme; doesn't compete with the main CTAs
- Responsive — centers on mobile, left-aligns on desktop (matching the button row)
- Fade-in animation consistent with surrounding hero elements

## What was not changed

- Hero headline, subtitle, main CTA buttons
- Navbar, pricing, other homepage sections
- Auth / dashboard behavior

https://claude.ai/code/session_01TnAZmRCqnKY2TyBXaJDhiW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TnAZmRCqnKY2TyBXaJDhiW)_