### PR TITLE
Update Zachary Perez's location to California on About page

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -204,7 +204,7 @@ const founders: FounderCardProps[] = [
     name: "Zachary Perez",
     title: "Chief Strategy Officer",
     badge: "Co-Founder",
-    location: "Georgia",
+    location: "California",
     preview:
       "Zachary drives Dynasty's strategic direction with a focus on building something that lasts — systems designed to endure across market conditions.",
     fullBio: (


### PR DESCRIPTION
## Summary
- Updates Zachary Perez's location from `Georgia` to `California` in the Founders & Leadership section of the About page

## Final Founder Locations
- Brock Adams — Utah
- Zachary Perez — California
- Cliff Adams — Texas

## Test plan
- [ ] Navigate to `/about` and verify Zachary Perez's location displays as "California"
- [ ] Confirm no other founder cards or page elements were affected

https://claude.ai/code/session_01Jp4XuTLXxfL2RkUFaBq2Pk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jp4XuTLXxfL2RkUFaBq2Pk)_