### PR TITLE
Update footer LinkedIn URL to company page

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -101,7 +101,7 @@ const Footer = () => {
                   </svg>
                 </a>
                 <a
-                  href="https://www.linkedin.com/in/dynasty-futures-1639483b8"
+                  href="https://www.linkedin.com/company/dynasty-futures/"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label="LinkedIn"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Updated the footer LinkedIn link from the old profile URL (`linkedin.com/in/dynasty-futures-1639483b8`) to the official company page (`linkedin.com/company/dynasty-futures/`)
- The link already had `target="_blank"` and `rel="noopener noreferrer"` — no changes needed there
- Only `src/components/layout/Footer.tsx` was modified; no styling, icon, or layout changes

## Test plan

- [ ] Visit Home, Dashboard, Pricing, About, FAQ, Rules, and Affiliate pages — all share the global Footer component
- [ ] Click the LinkedIn icon in the footer and confirm it opens `https://www.linkedin.com/company/dynasty-futures/` in a new tab
- [ ] Confirm no other social links were affected

https://claude.ai/code/session_01497kVDd4hqoWTiQ63bjafx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01497kVDd4hqoWTiQ63bjafx)_