### PR TITLE
Update Discord CTA section to highlight 3 pre-launch giveaways

### DIFF
--- a/src/components/home/DiscordCTA.tsx
+++ b/src/components/home/DiscordCTA.tsx
@@ -15,10 +15,30 @@ const DiscordCTA = () => {
                 Join the <span className="text-gradient-animated">Discord</span>
               </h2>
 
-              <p className="text-lg text-muted-foreground mb-8 max-w-md">
-                We're giving away 5 Standard 50K accounts at launch. The first
-                100 members to join our Discord are automatically entered to win.
+              <p className="text-lg text-muted-foreground mb-4 max-w-md">
+                Join the Dynasty Futures Discord and get involved before launch.
               </p>
+
+              <p className="text-base text-muted-foreground mb-2 max-w-md">
+                We currently have <span className="text-foreground font-semibold">3 active pre-launch giveaways</span> with{" "}
+                <span className="text-foreground font-semibold">15 total Standard Accounts</span> being awarded:
+              </p>
+
+              <ul className="text-base text-muted-foreground mb-4 max-w-md space-y-1 list-none">
+                <li>• 5 × $25K Standard Accounts</li>
+                <li>• 5 × $50K Standard Accounts</li>
+                <li>• 5 × $100K Standard Accounts</li>
+              </ul>
+
+              <p className="text-sm text-muted-foreground mb-4 max-w-md">
+                Winners will be announced on launch day.
+              </p>
+
+              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-gold/40 bg-gold/10 mb-6">
+                <span className="text-sm font-semibold text-gold">
+                  15 Winners&nbsp;•&nbsp;15 Accounts&nbsp;•&nbsp;Launch Day Announcement
+                </span>
+              </div>
 
               <Button
                 size="lg"


### PR DESCRIPTION
## Summary

- Replaces the old single-giveaway copy in the "Join the Discord" section with updated messaging covering all 3 active pre-launch giveaways
- Lists all three prize tiers: 5×$25K, 5×$50K, and 5×$100K Standard Accounts (15 total)
- Adds a gold-highlighted badge: **"15 Winners • 15 Accounts • Launch Day Announcement"**
- Preserves the section title, Discord button, invite link, and all other page sections unchanged

## Test plan

- [ ] Verify the Discord CTA section shows the updated copy with all 3 giveaway tiers listed
- [ ] Confirm the gold badge renders correctly with the `border-gold/40 bg-gold/10 text-gold` Tailwind tokens
- [ ] Confirm the "Join the Discord" button still links to `https://discord.gg/CMwf9Nsysq`
- [ ] Check that the Hero, Pricing, Footer, and Navbar are unaffected
- [ ] Test on mobile (stacked layout) and desktop (side-by-side layout)

https://claude.ai/code/session_01EuuXijPCQwUWKuErZB6u1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuuXijPCQwUWKuErZB6u1K)_