### PR TITLE
Update Terms Section 11 profit split policy and fix footer links

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -13,20 +13,22 @@ const quickLinks = [
   { name: "Legal / Terms of Use", path: "/legal?tab=terms" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
   { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
+  { name: "Payment Disputes / Chargeback Policy", path: "/legal?tab=chargebacks" },
+  { name: "Risk Disclosure", path: "/legal?tab=risk" },
 ];
 
 const dynastyArticleLinks = [
   { name: "Essential Trading Rules Overview", path: "/legal?tab=trading-rules" },
   { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
   { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
-  { name: "Daily Loss Limit Explained", path: "/legal?tab=trading-rules&rule=daily-loss" },
+  { name: "Daily Loss Limit Explained", path: "/legal?tab=trading-rules&rule=daily-loss-limit" },
   { name: "Drawdown Rules Explained", path: "/legal?tab=trading-rules&rule=drawdown" },
   { name: "News Trading Policy", path: "/legal?tab=trading-rules&rule=news-trading" },
   { name: "Consistency Rule Explained", path: "/legal?tab=trading-rules&rule=consistency" },
   { name: "Position Size Limits", path: "/legal?tab=trading-rules&rule=position-size" },
   { name: "Profit Targets Explained", path: "/legal?tab=trading-rules&rule=profit-targets" },
   { name: "Payouts & Profit Split", path: "/legal?tab=trading-rules&rule=payouts-split" },
-  { name: "Account Violations & Resets", path: "/legal?tab=trading-rules&rule=violations" },
+  { name: "Account Violations & Resets", path: "/legal?tab=trading-rules&rule=violations-resets" },
   { name: "Copy Trading & Automated Systems Policy", path: "/legal?tab=trading-rules&rule=copy-trading" },
 ];
 

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -9,14 +9,14 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 const VALID_TABS = ["risk", "terms", "privacy", "refund", "restricted", "rise-payouts", "kyc-aml", "chargebacks", "trading-rules"];
 
 const RULE_EXPLAINERS = [
-  { id: "daily-loss", label: "Daily Loss Limit Explained" },
+  { id: "daily-loss-limit", label: "Daily Loss Limit Explained" },
   { id: "drawdown", label: "Drawdown Rules Explained" },
   { id: "news-trading", label: "News Trading Policy" },
   { id: "consistency", label: "Consistency Rule Explained" },
   { id: "position-size", label: "Position Size Limits" },
   { id: "profit-targets", label: "Profit Targets Explained" },
   { id: "payouts-split", label: "Payouts & Profit Split" },
-  { id: "violations", label: "Account Violations & Resets" },
+  { id: "violations-resets", label: "Account Violations & Resets" },
   { id: "copy-trading", label: "Copy Trading & Automated Systems Policy" },
 ];
 
@@ -513,12 +513,16 @@ const Legal = () => {
                         Payouts may be delayed, held, or denied due to compliance, fraud, trading rule violations, incomplete verification, payout provider requirements, or any other reason at Dynasty Futures' discretion.
                       </p>
                       <p>
-                        The following payout structure applies to funded accounts:
+                        Funded accounts operate on a 90/10 profit split unless otherwise stated by Dynasty Futures. Traders keep 90% of approved profits, while Dynasty Futures retains 10%.
+                      </p>
+                      <p>
+                        After five approved payouts, accounts may be internally reviewed for potential live trading consideration based on consistency, risk management, compliance history, operational availability, platform/broker support, and jurisdictional eligibility.
+                      </p>
+                      <p>
+                        Live trading placement is not guaranteed and remains subject to Dynasty Futures approval, compliance review, operational availability, platform/broker requirements, and jurisdictional eligibility.
                       </p>
                       <ul className="list-none space-y-1.5 pl-2">
                         {[
-                          "90/10 profit split for the first five approved payouts (90% to trader)",
-                          "80/20 profit split after five approved payouts (80% to trader)",
                           "Up to 4 payout requests per calendar month",
                           "Minimum 5 qualifying trading days between payout requests",
                           "50% withdrawal limit per payout request",
@@ -2118,7 +2122,7 @@ const Legal = () => {
                             { ok: false, text: "Trading freeze while a payout request is pending approval" },
                             { ok: true, text: "50% withdrawal limit per payout request" },
                             { ok: true, text: "Maximum 3 accounts across all plans" },
-                            { ok: true, text: "90/10 profit split for first 5 payouts; 80/20 thereafter" },
+                            { ok: true, text: "90/10 profit split — traders keep 90% of approved profits" },
                           ].map(({ ok, text }) => (
                             <div key={text} className="flex items-start gap-2 text-sm text-muted-foreground">
                               <span className={`mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${ok ? "bg-primary/60" : "bg-destructive/60"}`} />


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Terms of Use Section 11**: Removed all 80/20 profit split language. Replaced with current 90/10 policy, added language about post-5-payout internal review for live trading consideration, and added disclaimer that live trading is not guaranteed.
- **Trading rules summary**: Updated remaining 80/20 reference in the trading rules quick-reference list to reflect the 90/10 policy.
- **Footer quick links**: Added missing "Payment Disputes / Chargeback Policy" (`/legal?tab=chargebacks`) and "Risk Disclosure" (`/legal?tab=risk`) links.
- **Footer article links**: Fixed `daily-loss` → `daily-loss-limit` and `violations` → `violations-resets` to match the correct rule IDs in the Legal page.
- **Legal page rule IDs**: Updated `RULE_EXPLAINERS` to use `daily-loss-limit` and `violations-resets` so tab/rule routing resolves correctly.

## Test plan

- [ ] Navigate to `/legal?tab=terms` → Section 11 shows 90/10 policy with no 80/20 language
- [ ] Navigate to `/legal?tab=trading-rules&rule=daily-loss-limit` → correct article loads
- [ ] Navigate to `/legal?tab=trading-rules&rule=violations-resets` → correct article loads
- [ ] Footer "Daily Loss Limit Explained" link routes to correct article
- [ ] Footer "Account Violations & Resets" link routes to correct article
- [ ] Footer "Payment Disputes / Chargeback Policy" → `/legal?tab=chargebacks`
- [ ] Footer "Risk Disclosure" → `/legal?tab=risk`
- [ ] All footer links scroll to top of page on navigation
- [ ] Mobile footer links work identically to desktop

https://claude.ai/code/session_01Wx9N2oWbtMs4QmSEiDwBua
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wx9N2oWbtMs4QmSEiDwBua)_