### PR TITLE
Add Crisp live-chat support widget

### DIFF
--- a/.env
+++ b/.env
@@ -16,3 +16,6 @@ VITE_SUPPORT_EMAIL=support@dynastyfuturesdyn.com
 
 # Google OAuth Client ID (get from Google Cloud Console)
 VITE_GOOGLE_CLIENT_ID=354088830154-utdcv1nd9k9o9r228b763l43n3n4il26.apps.googleusercontent.com
+
+# Crisp live-chat Website ID (Crisp → Settings → Website Settings → Setup)
+VITE_CRISP_WEBSITE_ID=a61614e7-2f31-4da8-8551-a21751860b73

--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,7 @@ VITE_SUPPORT_EMAIL=support@dynastyfuturesdyn.com
 
 # Google OAuth Client ID (get from Google Cloud Console)
 VITE_GOOGLE_CLIENT_ID=
+
+# Crisp live-chat Website ID (UUID from Crisp → Settings → Website Settings → Setup)
+# Leave empty to disable the chat widget. Safe to commit — it's public by design.
+VITE_CRISP_WEBSITE_ID=

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "crisp-sdk-web": "^1.1.2",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.38.0",
@@ -3574,6 +3575,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/crisp-sdk-web": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/crisp-sdk-web/-/crisp-sdk-web-1.1.2.tgz",
+      "integrity": "sha512-qxSpiT4EGHnVEO6J/t1UURY6fg1ojgquLU0IIr7RNjZxXZs1R2e6AhAiFqxiGZ13Vb4o5VoUpATFU2TzX/ppOQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "crisp-sdk-web": "^1.1.2",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.38.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { getPerfFlags } from "@/lib/perfFlags";
 import CookieConsentBanner from "@/components/ui/CookieConsentBanner";
+import CrispChat from "@/components/integrations/CrispChat";
 
 // Keep home route eagerly loaded; lazy-load the rest.
 import Index from "./pages/Index";
@@ -134,6 +135,7 @@ const App = () => {
             <TooltipProvider>
               <Toaster />
               <Sonner />
+              <CrispChat />
               <BrowserRouter>
                 <ScrollToTop />
                 <AppRoutes />

--- a/src/components/integrations/CrispChat.tsx
+++ b/src/components/integrations/CrispChat.tsx
@@ -1,0 +1,71 @@
+// =============================================================================
+// Dynasty Futures - Crisp Live Chat
+// =============================================================================
+// Mounts the Crisp chat widget site-wide and keeps it in sync with auth state.
+//
+// - Boots Crisp once. The SDK is dynamically imported inside an effect so it
+//   stays out of the SSR/prerender path (effects never run during
+//   renderToString) and is code-split out of the main bundle.
+// - When a trader is logged in, identifies them to the support team (email,
+//   name, and useful session context) so agents have full context in the inbox.
+// - On logout, resets the Crisp session so the next person on a shared device
+//   starts a clean, anonymous conversation.
+//
+// Renders nothing. No-ops entirely when VITE_CRISP_WEBSITE_ID is unset.
+// =============================================================================
+
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { env } from '@/config/env';
+
+const CrispChat = () => {
+  const { user } = useAuth();
+
+  // Crisp.configure() must run exactly once; subsequent renders only update
+  // identity. Refs survive re-renders without retriggering effects.
+  const configuredRef = useRef(false);
+  // Only reset the session on a real logout (a prior identified -> null
+  // transition), never on the initial anonymous render.
+  const wasIdentifiedRef = useRef(false);
+
+  useEffect(() => {
+    if (!env.crispWebsiteId) return;
+
+    let cancelled = false;
+
+    // Dynamic import is cached after the first call, so re-running this effect
+    // on every `user` change resolves instantly without re-fetching the SDK.
+    void import('crisp-sdk-web').then(({ Crisp }) => {
+      if (cancelled) return;
+
+      if (!configuredRef.current) {
+        Crisp.configure(env.crispWebsiteId);
+        configuredRef.current = true;
+      }
+
+      if (user) {
+        Crisp.user.setEmail(user.email);
+        Crisp.user.setNickname(`${user.firstName} ${user.lastName}`.trim());
+        Crisp.session.setData({
+          user_id: user.id,
+          role: user.role,
+          status: user.status,
+          kyc_status: user.kycStatus,
+          accounts: user._count?.accounts ?? 0,
+        });
+        wasIdentifiedRef.current = true;
+      } else if (wasIdentifiedRef.current) {
+        Crisp.session.reset();
+        wasIdentifiedRef.current = false;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user]);
+
+  return null;
+};
+
+export default CrispChat;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -35,6 +35,13 @@ export const env = {
   /** Google OAuth Client ID (required for Google SSO) */
   googleClientId: import.meta.env.VITE_GOOGLE_CLIENT_ID || '',
 
+  /**
+   * Crisp live-chat Website ID (a UUID from Crisp → Settings → Website
+   * Settings → Setup). When empty, the chat widget is disabled entirely.
+   * This value is public by design (baked into the client bundle).
+   */
+  crispWebsiteId: import.meta.env.VITE_CRISP_WEBSITE_ID || '',
+
   /** True when running `npm run build` (NODE_ENV=production) */
   isProduction: import.meta.env.PROD,
 


### PR DESCRIPTION
## What

Adds the **Crisp** live-chat widget across the whole site (public marketing pages + authenticated dashboard) as Dynasty Futures' new support channel.

## How

- New render-null `src/components/integrations/CrispChat.tsx`, mounted in `App.tsx` inside `<AuthProvider>`.
- A single effect (keyed on the authed `user`) boots Crisp once, then **identifies logged-in traders** to support — email, nickname, and session data (`user_id`, `role`, `status`, `kyc_status`, `accounts`). On logout it calls `Crisp.session.reset()` so the next person on a shared device starts a clean conversation.
- The SDK is **dynamically imported inside the effect**, so it stays out of the SSR/prerender path and is **code-split** into its own lazy chunk (~14 kB / 2.75 kB gzip).
- Driven by the new typed env var `VITE_CRISP_WEBSITE_ID` (in `src/config/env.ts`). When it's unset the guard constant-folds and the entire SDK **tree-shakes out** (zero bytes). The ID is committed in `.env` (shared, non-secret — it's public by design and lives in the client bundle), so it ships to prod automatically.

## Scope notes

- The existing **ticketing system is untouched** (`/support` form, `/dashboard/help`, `POST /v1/support`). Crisp is an *additional* real-time channel, not a replacement.
- **Email consolidation** (forwarding `support@` into the Crisp inbox) is a separate Microsoft 365 / Crisp dashboard config step — no code, handled outside this PR.

## Verification

- `npm run build` — clean; all 11 routes prerender with no `window is not defined`. Crisp emits a separate lazy chunk when the ID is set, and is absent from the bundle when unset.
- `npm run lint` — repo baseline unchanged (no new errors/warnings from these files).
- Live: anonymous visitor message reaches the Crisp inbox; after login the conversation shows the trader's identity + session data; logout resets the session.
