### PR TITLE
fix(legal): sync active tab/rule from URL on footer link navigation

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -13,15 +13,14 @@ const quickLinks = [
   { name: "Legal / Terms of Use", path: "/legal?tab=terms" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
   { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
-  { name: "Payment Disputes / Chargeback Policy", path: "/legal?tab=chargebacks" },
+  { name: "Payment Disputes", path: "/legal?tab=chargebacks" },
   { name: "Risk Disclosure", path: "/legal?tab=risk" },
+  { name: "Trading Rules", path: "/legal?tab=trading-rules" },
+  { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
+  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
 ];
 
 const dynastyArticleLinks = [
-  { name: "Essential Trading Rules Overview", path: "/legal?tab=trading-rules" },
-  { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
-  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
-  { name: "Daily Loss Limit Explained", path: "/legal?tab=trading-rules&rule=daily-loss-limit" },
   { name: "Drawdown Rules Explained", path: "/legal?tab=trading-rules&rule=drawdown" },
   { name: "News Trading Policy", path: "/legal?tab=trading-rules&rule=news-trading" },
   { name: "Consistency Rule Explained", path: "/legal?tab=trading-rules&rule=consistency" },

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -13,14 +13,15 @@ const quickLinks = [
   { name: "Legal / Terms of Use", path: "/legal?tab=terms" },
   { name: "Refund & Cancellation Policy", path: "/legal?tab=refund" },
   { name: "Restricted Countries & Regions", path: "/legal?tab=restricted" },
-  { name: "Payment Disputes", path: "/legal?tab=chargebacks" },
+  { name: "Payment Disputes / Chargeback Policy", path: "/legal?tab=chargebacks" },
   { name: "Risk Disclosure", path: "/legal?tab=risk" },
-  { name: "Trading Rules", path: "/legal?tab=trading-rules" },
-  { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
-  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
 ];
 
 const dynastyArticleLinks = [
+  { name: "Essential Trading Rules Overview", path: "/legal?tab=trading-rules" },
+  { name: "KYC & AML Policy", path: "/legal?tab=kyc-aml" },
+  { name: "Rise Payout Guide", path: "/legal?tab=rise-payouts" },
+  { name: "Daily Loss Limit Explained", path: "/legal?tab=trading-rules&rule=daily-loss-limit" },
   { name: "Drawdown Rules Explained", path: "/legal?tab=trading-rules&rule=drawdown" },
   { name: "News Trading Policy", path: "/legal?tab=trading-rules&rule=news-trading" },
   { name: "Consistency Rule Explained", path: "/legal?tab=trading-rules&rule=consistency" },

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useSearchParams, useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
 import PageMeta from "@/components/seo/PageMeta";
@@ -31,6 +31,16 @@ const Legal = () => {
     ruleParam && RULE_EXPLAINERS.some(r => r.id === ruleParam) ? ruleParam : null
   );
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const tab = searchParams.get("tab");
+    const rule = searchParams.get("rule");
+    if (tab && VALID_TABS.includes(tab)) {
+      setActiveTab(tab);
+    }
+    setActiveRule(rule && RULE_EXPLAINERS.some(r => r.id === rule) ? rule : null);
+    window.scrollTo({ top: 0, behavior: "instant" });
+  }, [searchParams]);
 
   const handleSetActiveRule = (id: string | null) => {
     setActiveRule(id);


### PR DESCRIPTION
## Problem

Footer links like `/legal?tab=refund`, `/legal?tab=kyc-aml`, `/legal?tab=trading-rules&rule=drawdown` were not opening the correct tab.

The root cause: `activeTab` and `activeRule` were initialized with `useState` from `searchParams` — but `useState` only runs its initializer **once on mount**. When React Router navigates between footer links (all pointing to `/legal?tab=...`), the Legal page component doesn't remount, so the tab state never updated from the new URL.

## Fix

Added a `useEffect` in `src/pages/Legal.tsx` that watches `searchParams` and reactively syncs `activeTab`, `activeRule`, and scroll position whenever the URL changes:

```ts
useEffect(() => {
  const tab = searchParams.get("tab");
  const rule = searchParams.get("rule");
  if (tab && VALID_TABS.includes(tab)) setActiveTab(tab);
  setActiveRule(rule && RULE_EXPLAINERS.some(r => r.id === rule) ? rule : null);
  window.scrollTo({ top: 0, behavior: "instant" });
}, [searchParams]);
```

No footer links, layout, styling, or content changed.

## Test plan
- [ ] Click each Quick Links legal footer link — verify the correct tab activates on `/legal`
- [ ] Click each Dynasty Articles rule link — verify the correct article opens under Rule Explainers
- [ ] Navigate between multiple footer links back-to-back — verify each one switches the tab correctly
- [ ] Verify page scrolls to top on each navigation
- [ ] Test on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxZa4BjsQfLZsB2CQaeMuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxZa4BjsQfLZsB2CQaeMuh)_