### PR TITLE
Surface KYC status + working verification CTA on profile

### DIFF
--- a/src/pages/dashboard/DashboardProfile.tsx
+++ b/src/pages/dashboard/DashboardProfile.tsx
@@ -39,6 +39,10 @@ import type { User as UserType } from "@/types/user";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useUserPlatformProfile } from "@/hooks/useUsers";
 
+// KYC is completed in the YPF-hosted trading portal (it owns identity
+// verification); we surface status here and hand off to complete/resubmit.
+const KYC_PORTAL_URL = "https://admin.dynastyfuturesdyn.com";
+
 const DashboardProfile = () => {
   const { user, refreshUser } = useAuth();
 
@@ -676,11 +680,37 @@ const DashboardProfile = () => {
                 </div>
               </div>
 
-              <div className="p-4 rounded-xl bg-yellow-500/10 border border-yellow-500/20 mb-8">
-                <p className="text-sm text-yellow-500">
-                  Verification is required before payouts can be processed.
-                </p>
-              </div>
+              {(() => {
+                const status = user?.kycStatus ?? "NOT_STARTED";
+                const cfg = {
+                  APPROVED: {
+                    cls: "bg-primary/10 border-primary/20 text-primary",
+                    icon: <CheckCircle size={18} className="text-primary shrink-0 mt-0.5" />,
+                    msg: "Your identity is verified — you're all set for payouts.",
+                  },
+                  PENDING: {
+                    cls: "bg-yellow-500/10 border-yellow-500/20 text-yellow-500",
+                    icon: <Loader2 size={18} className="text-yellow-500 shrink-0 mt-0.5 animate-spin" />,
+                    msg: "Your documents are under review. This page updates once verification completes.",
+                  },
+                  REJECTED: {
+                    cls: "bg-destructive/10 border-destructive/20 text-destructive",
+                    icon: <AlertCircle size={18} className="text-destructive shrink-0 mt-0.5" />,
+                    msg: "Verification wasn't approved. Please resubmit your documents in the trading portal.",
+                  },
+                  NOT_STARTED: {
+                    cls: "bg-yellow-500/10 border-yellow-500/20 text-yellow-500",
+                    icon: <AlertCircle size={18} className="text-yellow-500 shrink-0 mt-0.5" />,
+                    msg: "Verification is required before payouts can be processed.",
+                  },
+                }[status];
+                return (
+                  <div className={`p-4 rounded-xl border mb-8 flex items-start gap-3 ${cfg.cls}`}>
+                    {cfg.icon}
+                    <p className="text-sm">{cfg.msg}</p>
+                  </div>
+                );
+              })()}
 
               <div className="mb-8">
                 <Progress value={kycProgress} className="h-2 bg-muted/30" />
@@ -721,15 +751,21 @@ const DashboardProfile = () => {
 
               <p className="text-xs text-muted-foreground mt-6">
                 KYC status:{" "}
-                <span className="font-medium text-foreground">{user?.kycStatus ?? "—"}</span>
+                <span className="font-medium text-foreground">
+                  {user?.kycStatus ?? "NOT_STARTED"}
+                </span>
               </p>
 
-              {user?.kycStatus !== "APPROVED" && (
+              {user?.kycStatus !== "APPROVED" && user?.kycStatus !== "PENDING" && (
                 <Button
+                  asChild
                   className="w-full mt-4 btn-gradient-animated text-primary-foreground py-6 text-base"
-                  disabled
                 >
-                  Start Verification (coming soon)
+                  <a href={KYC_PORTAL_URL} target="_blank" rel="noopener noreferrer">
+                    {user?.kycStatus === "REJECTED"
+                      ? "Resubmit Verification"
+                      : "Start Verification"}
+                  </a>
                 </Button>
               )}
             </div>


### PR DESCRIPTION
## Summary
Refines the KYC tab on the dashboard Profile page so it reflects the trader's real verification state and gives them a working way to act on it.

Previously the tab showed a static yellow "verification required" banner and a **disabled** "Start Verification (coming soon)" button — dead UI regardless of where the trader actually stood.

## Changes
- **Status-driven banner** keyed off `user.kycStatus` with distinct icon/color/copy for each state:
  - `NOT_STARTED` — yellow, "verification required before payouts"
  - `PENDING` — yellow + spinner, "documents under review"
  - `APPROVED` — primary/green, "you're all set for payouts"
  - `REJECTED` — destructive/red, "resubmit your documents"
- **Working CTA** replacing the disabled button: hands off to the YPF-hosted trading portal (`admin.dynastyfuturesdyn.com`) where identity verification actually runs. Label is "Start Verification" / "Resubmit Verification" based on status, and the button is hidden entirely when `APPROVED` or `PENDING`.

## Why the portal hand-off
KYC is owned by YPF's trading platform, not DF. We surface status here and route the trader to the portal to complete/resubmit. (A future option is wiring the spec's `PUT /users/{userId}/requestkyc` through our backend instead of a portal link.)

## Verification
- `npm run build` clean — 11 routes prerender.
- `npm run lint` — unchanged baseline (6 errors / 23 warnings, all pre-existing elsewhere).
- All three icons (`CheckCircle` / `Loader2` / `AlertCircle`) already imported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
