### PR TITLE
Populate dashboard from live trades + derive calendar/equity from trades

### DIFF
--- a/src/components/dashboard/DailyAnalytics.tsx
+++ b/src/components/dashboard/DailyAnalytics.tsx
@@ -17,8 +17,9 @@ interface TradeHighlight {
 
 const DailyAnalytics = ({ accountId, selectedDate = new Date() }: DailyAnalyticsProps) => {
   const { data: account } = useAccountView(accountId);
-  // Shares the trades query with useAccountView (same React Query key — no extra fetch).
-  const tradesQ = useAccountTrades(accountId);
+  // Shares the trades query with useAccountView (same React Query key — no extra
+  // fetch). Must match useAccountView's `{ live: true }` so they stay one query.
+  const tradesQ = useAccountTrades(accountId, { live: true });
   const trades = useMemo(() => tradesQ.data?.data ?? [], [tradesQ.data]);
   const dailyPnL = useMemo(() => account?.dailyPnL ?? [], [account]);
 

--- a/src/hooks/useAccountView.ts
+++ b/src/hooks/useAccountView.ts
@@ -30,7 +30,9 @@ export interface AccountViewResult {
 export const useAccountView = (accountId: string | undefined): AccountViewResult => {
   const accountQ = useTradingAccount(accountId);
   const snapshotsQ = useAccountSnapshots(accountId);
-  const tradesQ = useAccountTrades(accountId);
+  // Pull trades live so a freshly-viewed account syncs its YPF history into the
+  // dashboard's derived metrics (win rate, sessions, calendar, streaks).
+  const tradesQ = useAccountTrades(accountId, { live: true });
 
   const data = useMemo<AccountData | null>(() => {
     if (!accountQ.data?.data) return null;

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -121,6 +121,53 @@ const buildSeries = (
 };
 
 // ---------------------------------------------------------------------------
+// Fallback equity/daily-P&L series derived from closed trades, used when the
+// backend has no daily snapshots (YPF exposes no daily-snapshot time series, so
+// snapshots are usually empty). Same dense oldest→newest, last == today layout
+// as buildSeries so the calendar + equity curve read it unchanged.
+// ---------------------------------------------------------------------------
+
+const buildSeriesFromTrades = (
+  trades: Trade[],
+  startingBalance: number,
+  currentBalance: number,
+): { equityHistory: number[]; dailyPnL: number[] } => {
+  const closed = trades
+    .filter((t) => t.exitTime && t.realizedPnl !== null)
+    .map((t) => ({
+      day: new Date(t.exitTime as string).toISOString().slice(0, 10),
+      pnl: num(t.realizedPnl),
+    }));
+
+  if (!closed.length) {
+    return { equityHistory: [currentBalance || startingBalance], dailyPnL: [0] };
+  }
+
+  const byDay = new Map<string, number>();
+  for (const c of closed) byDay.set(c.day, (byDay.get(c.day) ?? 0) + c.pnl);
+
+  const firstKey = closed.reduce((min, c) => (c.day < min ? c.day : min), closed[0]!.day);
+  const first = new Date(`${firstKey}T00:00:00`);
+  const today = new Date();
+  const totalDays = differenceInCalendarDays(today, first) + 1;
+
+  const equityHistory: number[] = [];
+  const dailyPnL: number[] = [];
+  let runningBalance = startingBalance;
+
+  for (let i = 0; i < totalDays; i++) {
+    const day = new Date(first);
+    day.setDate(first.getDate() + i);
+    const dayPnl = byDay.get(day.toISOString().slice(0, 10)) ?? 0;
+    runningBalance += dayPnl;
+    equityHistory.push(runningBalance);
+    dailyPnL.push(dayPnl);
+  }
+
+  return { equityHistory, dailyPnL };
+};
+
+// ---------------------------------------------------------------------------
 // Trades → win rate, avg win, avg loss, gross profit/loss, session perf,
 // day-of-week perf, streaks. All derived; if no trades, fields zero out.
 // ---------------------------------------------------------------------------
@@ -257,7 +304,11 @@ export const adaptAccountView = (
     startingBalance,
   );
 
-  const series = buildSeries(snapshots, startingBalance, currentBalance);
+  // Prefer real daily snapshots; fall back to a trade-derived series when the
+  // backend has none (the common case, since YPF has no snapshot time series).
+  const series = snapshots.length
+    ? buildSeries(snapshots, startingBalance, currentBalance)
+    : buildSeriesFromTrades(trades, startingBalance, currentBalance);
   const derived = computeMetrics(trades);
 
   // currentDrawdown is a percentage in the DB (Decimal(5,2)); convert to money


### PR DESCRIPTION
## Why
The dashboard's Advanced Metrics, Daily Analytics, session/day-of-week performance, streaks, and the daily performance calendar were empty for real accounts. They all derive from **trades** (and **snapshots**), which weren't reaching the widgets. Pairs with backend PR (YPF trade-history mapper fix).

## Changes
1. **Fetch trades live.** `useAccountView` — and `DailyAnalytics`, which shares its trades query (same React Query key) — now request trades with `live: true`. Viewing an account syncs its YPF history into the derived metrics (win rate, avg win/loss, profit factor, sessions, day-of-week, streaks, Daily Analytics).
2. **Trade-derived calendar + equity.** `tradingAdapter` now derives the equity curve and daily-P&L series from closed trades when there are no daily snapshots. YPF has no daily-snapshot time series (`/dailydrawdown` is a single current-state object), so snapshots are normally empty — the trade-derived series fills the Daily Performance Calendar and equity widgets. Real snapshots still take precedence when present.

## Notes
- Everything stays real-derived — no fabricated numbers. Sparse accounts (few trades) show sparse-but-accurate data.
- The instrument-breakdown and trade-direction panels remain explicit stubs (pre-existing TODOs, need per-trade instrument aggregation) — out of scope here.

## Verified
- `npm run build` clean (11 routes prerender) · lint = baseline (6/23, all pre-existing).
- Backend companion confirmed live: the real ES.CME trade syncs and feeds these widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
