### PR TITLE
Fix equity curve, P&L netting, and chart timeframes

### DIFF
--- a/src/components/dashboard/PerformanceChart.tsx
+++ b/src/components/dashboard/PerformanceChart.tsx
@@ -48,7 +48,7 @@ const CustomTooltip = ({ active, payload, label }: any) => {
         ))}
         {payload[0]?.payload?.pnl !== undefined && (
           <div className="mt-2 pt-2 border-t border-border/30">
-            <span className="text-xs text-muted-foreground">Daily P&L: </span>
+            <span className="text-xs text-muted-foreground">P&L: </span>
             <span
               className={`text-sm font-semibold ${payload[0].payload.pnl >= 0 ? "text-primary" : "text-destructive"}`}
             >
@@ -88,17 +88,14 @@ const PerformanceChart = ({
   timeframe,
   className,
 }: PerformanceChartProps) => {
-  const isDailyView = timeframe === 'daily';
-
-  // Calculate Y-axis domain — for daily view use only balance data so intraday movement is visible
+  // Y-axis domain is driven by the equity range itself (not the profit-target /
+  // max-loss rule lines) so per-trade dips/recoveries stay visible — a few-
+  // hundred-dollar swing on a six-figure account would otherwise flatten to a
+  // straight line. The rule lines still render as overlays when in range.
   const allBalances = data.map((d) => d.balance);
-  const minBalance = isDailyView
-    ? Math.min(...allBalances)
-    : Math.min(...allBalances, data[0]?.maxLoss || 0);
-  const maxBalance = isDailyView
-    ? Math.max(...allBalances)
-    : Math.max(...allBalances, data[0]?.profitTarget || 0);
-  const padding = Math.max((maxBalance - minBalance) * 0.15, isDailyView ? 30 : 0);
+  const minBalance = Math.min(...allBalances);
+  const maxBalance = Math.max(...allBalances);
+  const padding = Math.max((maxBalance - minBalance) * 0.15, 30);
 
   // Calculate P&L domain
   const allPnL = data.map((d) => d.pnl);
@@ -221,7 +218,14 @@ const PerformanceChart = ({
                 tickFormatter={(value) => `$${(value / 1000).toFixed(1)}k`}
                 domain={[minBalance - padding, maxBalance + padding]}
               />
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{
+                  stroke: "hsl(var(--primary))",
+                  strokeOpacity: 0.35,
+                  strokeWidth: 1,
+                }}
+              />
 
               {/* Profit Target Line - dashed, semi-transparent */}
               <ReferenceLine
@@ -281,7 +285,10 @@ const PerformanceChart = ({
                 }
                 domain={[minPnL - pnlPadding, maxPnL + pnlPadding]}
               />
-              <Tooltip content={<PnLTooltip />} />
+              <Tooltip
+                content={<PnLTooltip />}
+                cursor={{ fill: "hsl(var(--primary))", fillOpacity: 0.08 }}
+              />
               <ReferenceLine
                 y={0}
                 stroke="hsl(var(--border))"

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -23,6 +23,16 @@ export interface Streaks {
   currentStreak: number; // positive = winning, negative = losing
 }
 
+export interface ClosedTradePoint {
+  /** ISO close timestamp */
+  time: string;
+  /** Commission-netted realized P&L for this trade */
+  netPnl: number;
+  /** Running account equity after this trade closed */
+  equity: number;
+  symbol: string;
+}
+
 export interface AccountData {
   id: string;
   name: string;
@@ -55,6 +65,10 @@ export interface AccountData {
   streaks: Streaks;
   equityHistory: number[];
   dailyPnL: number[];
+  // Closed trades, oldest→newest by close time, with commission-netted P&L.
+  // Drives the per-trade running-equity curve so intraday dips/recoveries show
+  // instead of collapsing trades into one daily step.
+  closedTrades: ClosedTradePoint[];
   // Live platform fields (YPF) — only present on detail views with live data
   nextProgramName?: string;
   profitSplit?: number;
@@ -148,6 +162,7 @@ export const mockAccounts: AccountData[] = [
     },
     equityHistory: equity25K,
     dailyPnL: pnl25K,
+    closedTrades: [],
   },
   {
     id: '2',
@@ -196,6 +211,7 @@ export const mockAccounts: AccountData[] = [
     },
     equityHistory: equity50K,
     dailyPnL: pnl50K,
+    closedTrades: [],
   },
   {
     id: '3',
@@ -244,6 +260,7 @@ export const mockAccounts: AccountData[] = [
     },
     equityHistory: equity100K,
     dailyPnL: pnl100K,
+    closedTrades: [],
   },
 ];
 

--- a/src/lib/chartData.ts
+++ b/src/lib/chartData.ts
@@ -1,87 +1,165 @@
 // =============================================================================
 // Chart data builders
 // =============================================================================
-// Generates ChartDataPoint[] for the dashboard's PerformanceChart from a
-// real AccountData view shape. Replaces the synthetic generateChartData()
-// helper from mockDashboardData.
+// Generates ChartDataPoint[] for the dashboard's PerformanceChart from a real
+// AccountData view shape.
 //
-// Accepted timeframe tokens (origin/main vocabulary):
-//   - 'daily'   → 8 hourly points around the selected date's daily P&L
-//   - 'weekly'  → last 7 calendar days
-//   - 'monthly' → last 30 calendar days  (default fallback)
+// Primary path: a PER-TRADE running-equity curve built from account.closedTrades
+// (oldest→newest, commission-netted). This mirrors what the trading platform
+// plots — equity steps once per closed trade, so an early losing trade shows a
+// dip before later wins recover it, instead of collapsing a whole day into one
+// step. The P&L view shows each trade's net P&L as a bar.
 //
-// Legacy numeric tokens '1'|'7'|'30'|'90' still map to the same buckets so
-// callers can migrate gradually.
+// Accepted timeframe tokens:
+//   - 'daily'   → per-TRADE intraday curve for the selected day
+//   - 'weekly'  → per-DAY closing-equity over the last 7 days
+//   - 'monthly' → per-DAY closing-equity over the last ~3 months (90 days)
+//
+// The weekly/monthly views span the FULL calendar window (today − N … today),
+// not just the days that had trades — no-trade days carry the prior equity
+// flat — so changing the range visibly changes the chart's span.
 // =============================================================================
 
-import { differenceInCalendarDays, format, setHours, subDays } from 'date-fns';
-import type { AccountData, ChartDataPoint } from '@/data/mockDashboardData';
+import { addDays, format, isSameDay, startOfDay, subDays } from 'date-fns';
+import type {
+  AccountData,
+  ChartDataPoint,
+  ClosedTradePoint,
+} from '@/data/mockDashboardData';
 
 const tfDays = (tf: string): number => {
   if (tf === 'weekly' || tf === '7') return 7;
-  if (tf === '90') return 90;
-  return 30; // 'monthly' default
+  if (tf === 'monthly' || tf === '90') return 90; // ~3 months
+  if (tf === '30') return 30;
+  return 90;
 };
 
 const isDailyTf = (tf: string): boolean => tf === 'daily' || tf === '1';
+
+// Filter closed trades to the active timeframe window.
+// Build a per-trade running-equity series for a single day. The leading "Start"
+// point anchors the curve at the equity *before* the first trade, so the first
+// trade's bar/step is visible. Equity values are absolute (cumulative from the
+// account's true starting balance), already computed in the adapter.
+const buildFromTrades = (
+  account: AccountData,
+  windowed: ClosedTradePoint[],
+): ChartDataPoint[] => {
+  const profitTarget = account.startingBalance + account.profitTarget;
+  const maxLoss = account.startingBalance - account.maxDrawdown;
+  const labelFmt = 'h:mm a';
+
+  const first = windowed[0]!;
+  const baseEquity = first.equity - first.netPnl;
+
+  const points: ChartDataPoint[] = [
+    {
+      date: 'Start',
+      balance: Math.round(baseEquity),
+      maxLoss,
+      profitTarget,
+      pnl: 0,
+    },
+  ];
+
+  for (const t of windowed) {
+    points.push({
+      date: format(new Date(t.time), labelFmt),
+      balance: Math.round(t.equity),
+      maxLoss,
+      profitTarget,
+      pnl: Math.round(t.netPnl),
+    });
+  }
+
+  return points;
+};
+
+// Per-day closing-equity series for the weekly/monthly (zoomed-out) views.
+// Spans the FULL window (today − N + 1 … today) directly from closedTrades:
+// each day's bar is that day's net P&L and the line is the running equity, so
+// no-trade days carry the prior balance flat. Weekly (7 pts) and monthly
+// (~90 pts) therefore differ by span even when trades cluster on one day.
+const buildFromDaySeries = (
+  account: AccountData,
+  timeframe: string,
+): ChartDataPoint[] => {
+  const profitTarget = account.startingBalance + account.profitTarget;
+  const maxLoss = account.startingBalance - account.maxDrawdown;
+  const days = tfDays(timeframe);
+  const windowStart = subDays(startOfDay(new Date()), days - 1);
+
+  // Net P&L per calendar day, and the equity carried into the window (starting
+  // balance plus everything realized before the window began).
+  const pnlByDay = new Map<string, number>();
+  let equity = account.startingBalance;
+  for (const t of account.closedTrades) {
+    const when = new Date(t.time);
+    if (when < windowStart) {
+      equity += t.netPnl;
+    } else {
+      const key = format(when, 'yyyy-MM-dd');
+      pnlByDay.set(key, (pnlByDay.get(key) ?? 0) + t.netPnl);
+    }
+  }
+
+  // No trade history at all → flat line at the current balance across the span.
+  if (!account.closedTrades.length) {
+    equity = account.currentBalance || account.startingBalance;
+  }
+
+  const points: ChartDataPoint[] = [];
+  for (let i = 0; i < days; i++) {
+    const day = addDays(windowStart, i);
+    const dayPnl = pnlByDay.get(format(day, 'yyyy-MM-dd')) ?? 0;
+    equity += dayPnl;
+    points.push({
+      date: format(day, 'MMM d'),
+      balance: Math.round(equity),
+      maxLoss,
+      profitTarget,
+      pnl: Math.round(dayPnl),
+    });
+  }
+
+  return points;
+};
+
+// Flat single-point baseline — shown when the selected window has no trades
+// (e.g. "daily" on a day the trader didn't trade).
+const flatBaseline = (account: AccountData): ChartDataPoint[] => {
+  const profitTarget = account.startingBalance + account.profitTarget;
+  const maxLoss = account.startingBalance - account.maxDrawdown;
+  return [
+    {
+      date: format(new Date(), 'MMM d'),
+      balance: account.currentBalance || account.startingBalance,
+      maxLoss,
+      profitTarget,
+      pnl: 0,
+    },
+  ];
+};
 
 export const buildChartData = (
   account: AccountData,
   timeframe: string,
   selectedDate?: Date,
 ): ChartDataPoint[] => {
-  const today = new Date();
-  const profitTarget = account.startingBalance + account.profitTarget;
-  const maxLoss = account.startingBalance - account.maxDrawdown;
-
-  // Intraday — synthesize hourly points around the selected day's P&L. Real
-  // intraday data isn't exposed by /v1/trading; this is the best we can do
-  // without a per-tick endpoint, but it's deterministic given a fixed date.
+  // Daily → a per-TRADE intraday curve for the selected day, so a losing trade
+  // early in the session shows a dip before later wins recover it.
   if (isDailyTf(timeframe)) {
-    const target = selectedDate ?? today;
-    const daysAgo = Math.max(
-      0,
-      differenceInCalendarDays(today, target),
+    const target = selectedDate ?? new Date();
+    const dayTrades = account.closedTrades.filter((t) =>
+      isSameDay(new Date(t.time), target),
     );
-    const idx = account.dailyPnL.length - 1 - daysAgo;
-    const dayPnl =
-      idx >= 0 && idx < account.dailyPnL.length ? account.dailyPnL[idx] : 0;
-    const dayClose =
-      idx >= 0 && idx < account.equityHistory.length
-        ? account.equityHistory[idx]
-        : account.currentBalance;
-    const dayOpen = dayClose - dayPnl;
-    const hourlyVariation = dayPnl / 8;
-
-    const data: ChartDataPoint[] = [];
-    for (let i = 0; i < 8; i++) {
-      const hour = setHours(target, 9 + i);
-      data.push({
-        date: format(hour, 'ha'),
-        balance: Math.round(dayOpen + (i + 1) * hourlyVariation),
-        maxLoss,
-        profitTarget,
-        pnl: Math.round(hourlyVariation),
-      });
-    }
-    return data;
+    return dayTrades.length
+      ? buildFromTrades(account, dayTrades)
+      : flatBaseline(account);
   }
 
-  const days = tfDays(timeframe);
-  const equity = account.equityHistory;
-  const pnl = account.dailyPnL;
-  const sliceStart = Math.max(0, equity.length - days);
-  const equitySlice = equity.slice(sliceStart);
-  const pnlSlice = pnl.slice(sliceStart);
-
-  return equitySlice.map((balance, index) => {
-    const date = subDays(today, equitySlice.length - 1 - index);
-    return {
-      date: format(date, 'MMM d'),
-      balance,
-      maxLoss,
-      profitTarget,
-      pnl: pnlSlice[index] ?? 0,
-    };
-  });
+  // Weekly / monthly → a per-DAY closing-equity series (zoomed out). Distinct
+  // from the daily view's per-trade granularity, so changing the range visibly
+  // changes the chart. Falls back to a flat baseline when there's no history.
+  return buildFromDaySeries(account, timeframe);
 };

--- a/src/lib/emptyAccountData.ts
+++ b/src/lib/emptyAccountData.ts
@@ -47,4 +47,5 @@ export const EMPTY_ACCOUNT_DATA: AccountData = {
   },
   equityHistory: [],
   dailyPnL: [],
+  closedTrades: [],
 };

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -10,7 +10,7 @@
 // =============================================================================
 
 import { differenceInCalendarDays } from 'date-fns';
-import type { AccountData } from '@/data/mockDashboardData';
+import type { AccountData, ClosedTradePoint } from '@/data/mockDashboardData';
 import type { Challenge } from '@/types/account';
 import type {
   AccountSnapshot,
@@ -25,6 +25,12 @@ const num = (v: string | number | null | undefined, fallback = 0): number => {
   const n = typeof v === 'number' ? v : Number(v);
   return Number.isFinite(n) ? n : fallback;
 };
+
+// Net realized P&L for a trade = gross realized P&L minus commission. YPF (and
+// the trader's platform) reports P&L net of commission, so every P&L figure we
+// derive — equity curve, calendar, day/session metrics — must net it too, or
+// our numbers drift above the platform's (e.g. $8,632 gross vs $6,806 net).
+const tradeNetPnl = (t: Trade): number => num(t.realizedPnl) - num(t.commission);
 
 // ---------------------------------------------------------------------------
 // Plan detection — backend doesn't have an explicit plan column. Best signal
@@ -136,7 +142,7 @@ const buildSeriesFromTrades = (
     .filter((t) => t.exitTime && t.realizedPnl !== null)
     .map((t) => ({
       day: new Date(t.exitTime as string).toISOString().slice(0, 10),
-      pnl: num(t.realizedPnl),
+      pnl: tradeNetPnl(t),
     }));
 
   if (!closed.length) {
@@ -168,6 +174,39 @@ const buildSeriesFromTrades = (
 };
 
 // ---------------------------------------------------------------------------
+// Closed trades → per-trade running-equity points (oldest→newest by close
+// time), starting from the account's true starting balance. This is what the
+// platform plots: equity steps once per closed trade (net of commission), so a
+// losing trade early in the session shows a dip before later wins recover it —
+// instead of collapsing a whole day into a single bar.
+// ---------------------------------------------------------------------------
+
+const buildClosedTrades = (
+  trades: Trade[],
+  startingBalance: number,
+): ClosedTradePoint[] => {
+  const closed = trades
+    .filter((t) => t.exitTime && t.realizedPnl !== null)
+    .sort(
+      (a, b) =>
+        new Date(a.exitTime as string).getTime() -
+        new Date(b.exitTime as string).getTime(),
+    );
+
+  let equity = startingBalance;
+  return closed.map((t) => {
+    const netPnl = tradeNetPnl(t);
+    equity += netPnl;
+    return {
+      time: t.exitTime as string,
+      netPnl,
+      equity,
+      symbol: t.symbol,
+    };
+  });
+};
+
+// ---------------------------------------------------------------------------
 // Trades → win rate, avg win, avg loss, gross profit/loss, session perf,
 // day-of-week perf, streaks. All derived; if no trades, fields zero out.
 // ---------------------------------------------------------------------------
@@ -195,7 +234,7 @@ const computeMetrics = (trades: Trade[]): {
   streaks: AccountData['streaks'];
 } => {
   const closed = trades.filter((t) => t.exitTime && t.realizedPnl !== null);
-  const pnls = closed.map((t) => num(t.realizedPnl));
+  const pnls = closed.map((t) => tradeNetPnl(t));
   const wins = pnls.filter((p) => p > 0);
   const losses = pnls.filter((p) => p < 0);
   const grossProfit = wins.reduce((s, p) => s + p, 0);
@@ -218,7 +257,7 @@ const computeMetrics = (trades: Trade[]): {
   };
 
   for (const t of closed) {
-    const pnl = num(t.realizedPnl);
+    const pnl = tradeNetPnl(t);
     const entry = new Date(t.entryTime);
     const dayKey = entry.toISOString().slice(0, 10);
     byDay.set(dayKey, (byDay.get(dayKey) ?? 0) + pnl);
@@ -342,6 +381,7 @@ export const adaptAccountView = (
     streaks: derived.streaks,
     equityHistory: series.equityHistory,
     dailyPnL: series.dailyPnL,
+    closedTrades: buildClosedTrades(trades, startingBalance),
     ...(live?.nextProgramName ? { nextProgramName: live.nextProgramName } : {}),
     ...(live?.profitSplit !== undefined ? { profitSplit: live.profitSplit } : {}),
     ...(live?.profitTradingDays !== undefined

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -59,7 +59,7 @@ const DashboardHome = () => {
     }
   }, [accounts, selectedAccount, urlAccountId]);
 
-  const [dateRange, setDateRange] = useState("monthly");
+  const [dateRange, setDateRange] = useState("daily");
   const [chartType, setChartType] = useState<"equity" | "pnl">("equity");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
 


### PR DESCRIPTION
## Problems
The dashboard charts didn''t match the trading platform:

1. **Closed P&L too high** — derived from gross (pre-commission) figures. Fixed in tandem with the backend `startingBalance` PR; here we net commission in every frontend P&L derivation.
2. **Equity curve only sloped up** — P&L was bucketed by calendar day, so a whole session of trades collapsed into a single up-step. No intraday dip ever showed.
3. **Timeframe buttons did nothing** — daily/weekly/monthly rendered the same curve.
4. **White-out on hover** — the default tooltip cursor is a near-white fill; with a single data point it washed out the entire chart.

## Changes
- **`tradingAdapter`**: net commission in every P&L derivation (equity, calendar, day/session metrics); expose `closedTrades` (sorted by close time, with net P&L + running equity) on `AccountData`.
- **`chartData`**:
  - Daily → a per-**trade** intraday running-equity curve, so an early losing trade dips before later wins recover it.
  - Weekly/Monthly → a per-**day** closing-equity series spanning the **full window** (last 7 days / last ~3 months), no-trade days carrying the prior equity flat. Changing the range now visibly changes the chart''s span.
- **`PerformanceChart`**: Y-axis scales to the equity range at all timeframes (a few-hundred-dollar swing on a six-figure account stays visible); subtle tooltip cursor instead of the white wash.
- **`DashboardHome`**: default timeframe is now **daily**.

## Verification
- Typecheck clean, `npm run build` clean (11 routes prerendered), changed files lint-clean.
- Validated the per-trade series against a real prod account (150K Advanced): dips to ~$148,261 on three early losers, recovers to $156,806.60 (closed P&L +$6,806.60) — matching the platform.

Pairs with DF-Backend #17 (startingBalance anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)