### PR TITLE
Fix pricing table text shifting on plan/size change

### DIFF
--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -496,7 +496,16 @@ const Pricing = () => {
 
                 {/* Data Display Table */}
                 <div className="rounded-xl border border-border/30 overflow-hidden mb-8">
-                  <table className="w-full text-sm">
+                  {/* table-fixed + explicit column widths so cell geometry
+                      stays constant when values change between sizes/plans —
+                      otherwise auto-layout resizes columns and the centered
+                      text visibly shifts on each click. */}
+                  <table className="w-full text-sm table-fixed">
+                    <colgroup>
+                      <col className="w-2/5" />
+                      <col className="w-[30%]" />
+                      <col className="w-[30%]" />
+                    </colgroup>
                     <thead>
                       <tr className="border-b border-border/30 bg-muted/20">
                         <th className="text-left py-4 px-5 font-semibold text-foreground">


### PR DESCRIPTION
## Problem
On the pricing page, clicking through account sizes or plans made the comparison-table text shift horizontally. The table used auto layout, so columns resized to fit each value (e.g. `$1,500` vs `None` vs `5 minis / 50 micros`) and the centered cells jumped on every click.

## Fix
`table-fixed` layout with explicit column widths (40% / 30% / 30%) so cell geometry stays constant regardless of content. No visual change beyond the stabilized columns.

## Verification
Typecheck clean, `npm run build` clean (11 routes prerendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
