### PR TITLE
Auto-refresh dashboard data (2-min poll + fresh on mount/focus)

### DIFF
--- a/src/hooks/useAccountView.ts
+++ b/src/hooks/useAccountView.ts
@@ -16,9 +16,17 @@ import {
   useTradingAccount,
   useAccountSnapshots,
   useAccountTrades,
+  LIVE_REFRESH_MS,
 } from '@/hooks/useTrading';
 import { adaptAccountView, type AccountData } from '@/lib/tradingAdapter';
 import type { ApiError } from '@/types/api';
+
+// Keep the viewed account's data live: refetch every mount/focus (staleTime 0)
+// and auto-refresh on an interval while the page sits open.
+const LIVE_QUERY_OPTS = {
+  staleTime: 0,
+  refetchInterval: LIVE_REFRESH_MS,
+} as const;
 
 export interface AccountViewResult {
   data: AccountData | null;
@@ -28,11 +36,11 @@ export interface AccountViewResult {
 }
 
 export const useAccountView = (accountId: string | undefined): AccountViewResult => {
-  const accountQ = useTradingAccount(accountId);
-  const snapshotsQ = useAccountSnapshots(accountId);
+  const accountQ = useTradingAccount(accountId, LIVE_QUERY_OPTS);
+  const snapshotsQ = useAccountSnapshots(accountId, undefined, LIVE_QUERY_OPTS);
   // Pull trades live so a freshly-viewed account syncs its YPF history into the
   // dashboard's derived metrics (win rate, sessions, calendar, streaks).
-  const tradesQ = useAccountTrades(accountId, { live: true });
+  const tradesQ = useAccountTrades(accountId, { live: true }, LIVE_QUERY_OPTS);
 
   const data = useMemo<AccountData | null>(() => {
     if (!accountQ.data?.data) return null;

--- a/src/hooks/useTrading.ts
+++ b/src/hooks/useTrading.ts
@@ -30,6 +30,12 @@ import type {
   ReportRange,
 } from '@/types/trading';
 
+// Dashboard data auto-refreshes on this cadence while a view is mounted, so a
+// trader sitting on the page sees new trades/balances/account changes without a
+// manual refresh. Paired with staleTime: 0 on the dashboard queries, every
+// mount and window-focus also pulls fresh (a hard refresh always does anyway).
+export const LIVE_REFRESH_MS = 120_000; // 2 minutes
+
 // =============================================================================
 // Query key factory
 // =============================================================================
@@ -64,6 +70,10 @@ export const useTradingAccounts = (
   useQuery<ApiResponse<TradingAccount[]>, ApiError>({
     queryKey: tradingKeys.list(opts),
     queryFn: () => tradingService.listAccounts(opts),
+    // Keep the account list live — so newly-discovered accounts appear and
+    // disabled ones drop off without a manual refresh. Overridable via options.
+    staleTime: 0,
+    refetchInterval: LIVE_REFRESH_MS,
     ...options,
   });
 


### PR DESCRIPTION
## What
Make the trader dashboard auto-refresh so data stays current without a manual refresh.

## Behavior
- **Hard refresh (F5):** already pulled fresh (full reload clears the cache) — unchanged.
- **Sitting on the page:** account list, detail, snapshots, and trades now auto-refresh every **2 minutes** (`LIVE_REFRESH_MS`), matching the server poll cadence. New trades, balance/metric changes, newly-discovered accounts, and disabled-account removals now show up on their own.
- **Navigating to a page / tabbing back:** `staleTime: 0` on these queries means every mount and window-focus pulls fresh instead of serving the 5-minute cache.

The live balance tile already polled every 30s; this extends freshness to the rest of the dashboard data.

## Changes
- `useTrading.ts` — export `LIVE_REFRESH_MS` (2 min); account-list query gets `staleTime: 0` + `refetchInterval`.
- `useAccountView.ts` — detail/snapshots/trades queries get `staleTime: 0` + `refetchInterval`.

Both overridable via per-call options. Polling pauses in background tabs (RQ default) and resumes on focus.

## Verification
Typecheck clean, lint clean, `npm run build` clean (11 routes prerendered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
