### PR TITLE
Hide Trade tab; launch platform via dashboard button

### DIFF
--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Menu, LayoutDashboard, Wallet, LineChart, CalendarClock, CreditCard, Banknote, Users, User, Trophy, HelpCircle } from 'lucide-react';
+import { Menu, LayoutDashboard, Wallet, CalendarClock, CreditCard, Banknote, Users, User, Trophy, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 
@@ -10,7 +10,8 @@ const siteIconSrc = '/favicon.png?v=20260406';
 const sidebarLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Wallet },
-  { name: 'Trade', path: '/dashboard/trade', icon: LineChart },
+  // 'Trade' tab hidden until the in-app Volumetrica embed is unblocked; traders
+  // launch via the "Launch Platform" button. Route + page kept for later.
   { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
   { name: 'Billing', path: '/dashboard/billing', icon: CreditCard },
   { name: 'Payouts', path: '/dashboard/payouts', icon: Banknote },

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -2,7 +2,6 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   Activity,
   Briefcase,
-  LineChart,
   CalendarClock,
   Receipt,
   ArrowDownToLine,
@@ -20,7 +19,9 @@ const siteIconSrc = '/favicon.png?v=20260406';
 const sidebarLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: Activity },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Briefcase },
-  { name: 'Trade', path: '/dashboard/trade', icon: LineChart },
+  // 'Trade' tab is hidden until the in-app Volumetrica embed is unblocked — for
+  // now traders launch the platform via the "Launch Platform" button. The
+  // /dashboard/trade route + page are intentionally kept for when the embed works.
   { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
   { name: 'Billing', path: '/dashboard/billing', icon: Receipt },
   { name: 'Payouts', path: '/dashboard/payouts', icon: ArrowDownToLine },


### PR DESCRIPTION
## What
Hide the **Trade** tab from the dashboard (desktop sidebar + mobile nav). Traders launch the trading platform via the existing **"Launch Platform"** button instead.

## Why
The in-app Volumetrica iframe on the Trade page is blocked upstream — our Volumetrica key can't mint a webapp token for YPF-provisioned traders (`User not found`, wrong org). The working path is the **hosted Volumetrica portal**: the Launch button opens `volumetrica.dynastyfuturesdyn.com`, where the trader signs in with their **email + per-account password** (shown in the dashboard's Platform Credentials panel).

The `/dashboard/trade` route + iframe page are **intentionally kept** (just unlinked from nav) for when the embed gets unblocked.

## Companion
Backend PR [#21](https://github.com/Dynasty-Futures/DF-Backend/pull/21) points the Launch button at the portal URL and sets the displayed Login credential to the trader's email.

## Testing
- `npm run build` clean (11 routes prerender)
- `npm run lint` at baseline (no new errors/warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
