### PR TITLE
Remove black oval styling from Trustpilot hero widget

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -796,7 +796,14 @@
   width: 100%;
   height: 52px;
   margin-top: 12px;
-  background: #101010;
-  border-radius: 999px;
-  overflow: hidden;
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+}
+
+@media (min-width: 769px) {
+  .trustpilot-hero-widget {
+    margin-left: -12px;
+  }
 }


### PR DESCRIPTION
## Summary

- Removes `background: #101010`, `border-radius: 999px`, and `overflow: hidden` from `.trustpilot-hero-widget` that were creating the black pill/oval shape behind the widget
- Sets `background: transparent`, `border-radius: 0`, `box-shadow: none`, `padding: 0` to clear all extra styling
- Adds `margin-left: -12px` on desktop (≥769px) to shift the widget slightly left, aligning it under the hero buttons

The official Trustpilot widget code, data attributes, and script are untouched.

## Test plan

- [ ] Confirm the black oval/pill no longer appears behind the Trustpilot widget in the hero section
- [ ] Confirm the Trustpilot widget itself still renders correctly (logo, stars, text)
- [ ] Confirm mobile/tablet layout is unchanged (no `margin-left` applied below 769px)
- [ ] Confirm desktop widget aligns cleanly under the hero CTA buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Uju8WGjrJRzjPRD7yg5v2

---
_Generated by [Claude Code](https://claude.ai/code/session_016Uju8WGjrJRzjPRD7yg5v2)_