### PR TITLE
Persist viewed account + server-backed journal; dashboard UI fixes

### DIFF
--- a/src/components/dashboard/BuilderPanel.tsx
+++ b/src/components/dashboard/BuilderPanel.tsx
@@ -322,7 +322,7 @@ const BuilderPanel = ({
                     if (day.isCurrentMonth && !day.isSaturday) {
                       onDateChange(day.date);
                       navigate(
-                        `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}`,
+                        `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}?account=${encodeURIComponent(accountId)}`,
                       );
                     }
                   }}
@@ -537,7 +537,7 @@ const BuilderPanel = ({
                           value,
                         ).toLocaleString()}`}
                       >
-                        <span className="text-[10px] font-medium text-foreground/80 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <span className="text-[10px] font-medium text-foreground/90">
                           {value >= 0 ? "+" : "-"}$
                           {Math.abs(value).toLocaleString()}
                         </span>

--- a/src/components/dashboard/PerformanceChart.tsx
+++ b/src/components/dashboard/PerformanceChart.tsx
@@ -198,7 +198,7 @@ const PerformanceChart = ({
           instead of stretching the axis. Flips to "breached" if equity dipped
           to it. The red line still renders when equity drops near it. */}
       {chartType === "equity" && hasMaxLoss && (
-        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+        <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
           <div className="flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold border text-destructive border-destructive/40 bg-destructive/10">
             {maxLossBreached
               ? "✗ Max loss breached"

--- a/src/components/dashboard/SummaryPanel.tsx
+++ b/src/components/dashboard/SummaryPanel.tsx
@@ -434,7 +434,7 @@ const SummaryPanel = ({
                     if (day.isCurrentMonth && !day.isSaturday) {
                       onDateChange(day.date);
                       navigate(
-                        `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}`,
+                        `/dashboard/journal/${format(day.date, "yyyy-MM-dd")}?account=${encodeURIComponent(accountId)}`,
                       );
                     }
                   }}
@@ -653,7 +653,7 @@ const SummaryPanel = ({
                           value,
                         ).toLocaleString()}`}
                       >
-                        <span className="text-[10px] font-medium text-foreground/80 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <span className="text-[10px] font-medium text-foreground/90">
                           {value >= 0 ? "+" : "-"}$
                           {Math.abs(value).toLocaleString()}
                         </span>

--- a/src/hooks/useJournal.ts
+++ b/src/hooks/useJournal.ts
@@ -1,0 +1,47 @@
+// =============================================================================
+// Dynasty Futures - Journal React Query Hooks
+// =============================================================================
+// Server-persisted daily journal notes, scoped to an account. Follows the
+// query-key factory pattern used across the dashboard hooks.
+// =============================================================================
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { journalService, type JournalEntry } from '@/services/journal';
+import type { ApiResponse, ApiError } from '@/types/api';
+
+export const journalKeys = {
+  all: ['journal'] as const,
+  entry: (accountId: string, date: string) =>
+    [...journalKeys.all, accountId, date] as const,
+};
+
+/**
+ * Fetch the journal entry for an account on a given day. Disabled until an
+ * account id is known.
+ */
+export const useJournalEntry = (accountId: string | undefined, date: string) =>
+  useQuery<ApiResponse<JournalEntry>, ApiError>({
+    queryKey: journalKeys.entry(accountId ?? '', date),
+    queryFn: () => journalService.get(accountId as string, date),
+    enabled: !!accountId,
+    staleTime: 30_000,
+  });
+
+/**
+ * Save (or clear) the journal entry for an account. Writes the result straight
+ * into the cache so the editor stays in sync without a refetch.
+ */
+export const useSaveJournalEntry = (accountId: string | undefined) => {
+  const qc = useQueryClient();
+  return useMutation<
+    ApiResponse<JournalEntry>,
+    ApiError,
+    { date: string; content: string }
+  >({
+    mutationFn: ({ date, content }) =>
+      journalService.save(accountId as string, date, content),
+    onSuccess: (data, { date }) => {
+      qc.setQueryData(journalKeys.entry(accountId ?? '', date), data);
+    },
+  });
+};

--- a/src/hooks/useSelectedAccount.ts
+++ b/src/hooks/useSelectedAccount.ts
@@ -1,0 +1,101 @@
+// =============================================================================
+// Dynasty Futures - Selected-account persistence hook
+// =============================================================================
+// Single source of truth for the dashboard's "currently viewed account".
+//
+// Resolution order: ?account= URL param → localStorage → first available id.
+// The resolved id is mirrored back into BOTH:
+//   - the URL query param (so a hard refresh and browser back/forward keep the
+//     account you were viewing), and
+//   - localStorage (so navigating to a param-less route — e.g. the journal's
+//     "Back to Dashboard" button — and returning keeps it too).
+//
+// This fixes two classes of bugs:
+//   1. Clicking a calendar day opened the journal for the WRONG account (the
+//      link dropped the account, so the journal fell back to accounts[0]).
+//   2. The viewed account didn't survive refreshes or round-trips into the
+//      calendar and back.
+// =============================================================================
+
+import { useCallback, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const STORAGE_KEY = 'df:selectedAccountId';
+
+const readStored = (): string => {
+  if (typeof window === 'undefined') return '';
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+};
+
+const writeStored = (id: string): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    /* storage unavailable (private mode / quota) — non-fatal */
+  }
+};
+
+/**
+ * Resolve + persist the currently-viewed account id.
+ *
+ * @param availableIds ids of the accounts currently loaded. Used to validate
+ *   the persisted/URL id (so a deleted account falls back cleanly) and to pick
+ *   a sane default. Pass `[]` while the account list is still loading — the
+ *   hook returns `''` and won't touch the URL until ids are known.
+ * @returns `[selectedAccountId, setSelectedAccount]`
+ */
+export function useSelectedAccount(
+  availableIds: string[],
+): readonly [string, (id: string) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlAccount = searchParams.get('account') ?? '';
+
+  const isKnown = (id: string) => id !== '' && availableIds.includes(id);
+
+  const stored = readStored();
+  const resolved = isKnown(urlAccount)
+    ? urlAccount
+    : isKnown(stored)
+      ? stored
+      : (availableIds[0] ?? '');
+
+  // Mirror the resolved id back into the URL + localStorage once it's known.
+  // Runs on mount and whenever resolution changes (e.g. accounts finish
+  // loading, or a stale id falls back to a valid one).
+  useEffect(() => {
+    if (!resolved) return;
+    writeStored(resolved);
+    if (resolved !== urlAccount) {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('account', resolved);
+          return next;
+        },
+        { replace: true },
+      );
+    }
+  }, [resolved, urlAccount, setSearchParams]);
+
+  const setSelectedAccount = useCallback(
+    (id: string) => {
+      writeStored(id);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('account', id);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return [resolved, setSelectedAccount] as const;
+}

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useTradingAccounts, useLiveAccount, tradingKeys } from "@/hooks/useTrading";
 import { useAccountView } from "@/hooks/useAccountView";
+import { useSelectedAccount } from "@/hooks/useSelectedAccount";
 import { buildChartData } from "@/lib/chartData";
 
 const DashboardHome = () => {
@@ -48,16 +49,10 @@ const DashboardHome = () => {
   const accountsQ = useTradingAccounts();
   const accounts = useMemo(() => accountsQ.data?.data ?? [], [accountsQ.data]);
 
-  const urlAccountId = searchParams.get("account") ?? undefined;
-  const [selectedAccount, setSelectedAccount] = useState<string>(
-    urlAccountId ?? "",
-  );
-
-  useEffect(() => {
-    if (!selectedAccount && accounts.length > 0) {
-      setSelectedAccount(urlAccountId ?? accounts[0].id);
-    }
-  }, [accounts, selectedAccount, urlAccountId]);
+  // Persisted selection: ?account= URL param + localStorage. Survives refreshes
+  // and round-trips into the calendar/journal and back.
+  const accountIds = useMemo(() => accounts.map((a) => a.id), [accounts]);
+  const [selectedAccount, setSelectedAccount] = useSelectedAccount(accountIds);
 
   const [dateRange, setDateRange] = useState("daily");
   const [chartType, setChartType] = useState<"equity" | "pnl">("equity");

--- a/src/pages/dashboard/DashboardJournal.tsx
+++ b/src/pages/dashboard/DashboardJournal.tsx
@@ -1,5 +1,5 @@
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
-import { useState, useEffect, useMemo } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { useState, useEffect, useMemo, useRef } from "react";
 import {
   format,
   parseISO,
@@ -35,6 +35,8 @@ import {
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { useTradingAccounts, useAccountTrades } from "@/hooks/useTrading";
+import { useSelectedAccount } from "@/hooks/useSelectedAccount";
+import { useJournalEntry, useSaveJournalEntry } from "@/hooks/useJournal";
 import type { Trade } from "@/types/trading";
 
 const formatCurrency = (value: number, showSign = true) => {
@@ -71,7 +73,6 @@ const formatDuration = (entryIso: string, exitIso: string | null): string => {
 
 const DashboardJournal = () => {
   const { date } = useParams<{ date: string }>();
-  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
 
   const selectedDate = useMemo(() => {
@@ -87,19 +88,16 @@ const DashboardJournal = () => {
 
   const dateKey = format(selectedDate, "yyyy-MM-dd");
 
-  // Account selection — prefer ?account= query param, fall back to first.
+  // Account selection — shared with the dashboard via ?account= + localStorage,
+  // so opening a calendar day shows the account you were viewing (not the first
+  // in the list) and switching here persists back to the dashboard.
   const accountsQ = useTradingAccounts();
   const accounts = useMemo(
     () => accountsQ.data?.data ?? [],
     [accountsQ.data],
   );
-  const initialAccountId = searchParams.get("account") ?? "";
-  const [accountId, setAccountId] = useState<string>(initialAccountId);
-  useEffect(() => {
-    if (!accountId && accounts.length > 0) {
-      setAccountId(initialAccountId || accounts[0].id);
-    }
-  }, [accounts, accountId, initialAccountId]);
+  const accountIds = useMemo(() => accounts.map((a) => a.id), [accounts]);
+  const [accountId, setAccountId] = useSelectedAccount(accountIds);
 
   const tradesQ = useAccountTrades(accountId || undefined);
   const allTrades = useMemo(() => tradesQ.data?.data ?? [], [tradesQ.data]);
@@ -146,24 +144,49 @@ const DashboardJournal = () => {
     };
   }, [dayTrades]);
 
-  // Journal entry — local notes layer, persisted to localStorage.
+  // Journal entry — server-persisted per account + day, so notes follow the
+  // trader across devices.
+  const entryQ = useJournalEntry(accountId || undefined, dateKey);
+  const saveMut = useSaveJournalEntry(accountId || undefined);
+
   const [journalEntry, setJournalEntry] = useState("");
+  // Clear the editor immediately on account/date switch (no stale flash of the
+  // previous day's note while the new one loads).
+  const syncedKeyRef = useRef("");
   useEffect(() => {
-    const saved = localStorage.getItem(`journal-${dateKey}`);
-    setJournalEntry(saved ?? "");
-  }, [dateKey]);
+    setJournalEntry("");
+    syncedKeyRef.current = "";
+  }, [accountId, dateKey]);
+  // Seed the editor once the entry for the current account/date resolves.
+  useEffect(() => {
+    const key = `${accountId}|${dateKey}`;
+    if (entryQ.isSuccess && syncedKeyRef.current !== key) {
+      setJournalEntry(entryQ.data.data.content);
+      syncedKeyRef.current = key;
+    }
+  }, [entryQ.isSuccess, entryQ.data, accountId, dateKey]);
 
   const handleSave = () => {
-    localStorage.setItem(`journal-${dateKey}`, journalEntry);
-    toast.success("Journal entry saved");
+    if (!accountId) return;
+    saveMut.mutate(
+      { date: dateKey, content: journalEntry },
+      {
+        onSuccess: () => toast.success("Journal entry saved"),
+        onError: () => toast.error("Failed to save journal entry"),
+      },
+    );
   };
+
+  const accountQuery = accountId
+    ? `?account=${encodeURIComponent(accountId)}`
+    : "";
 
   const navigateDay = (direction: "prev" | "next") => {
     const newDate =
       direction === "prev"
         ? subDays(selectedDate, 1)
         : addDays(selectedDate, 1);
-    navigate(`/dashboard/journal/${format(newDate, "yyyy-MM-dd")}`);
+    navigate(`/dashboard/journal/${format(newDate, "yyyy-MM-dd")}${accountQuery}`);
   };
 
   return (
@@ -174,7 +197,7 @@ const DashboardJournal = () => {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => navigate("/dashboard")}
+            onClick={() => navigate(`/dashboard${accountQuery}`)}
             className="gap-2"
           >
             <ArrowLeft size={16} />
@@ -471,9 +494,18 @@ const DashboardJournal = () => {
                     Journal Entry
                   </h3>
                 </div>
-                <Button size="sm" onClick={handleSave} className="gap-2">
-                  <Save size={14} />
-                  Save Entry
+                <Button
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={saveMut.isPending || !accountId}
+                  className="gap-2"
+                >
+                  {saveMut.isPending ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : (
+                    <Save size={14} />
+                  )}
+                  {saveMut.isPending ? "Saving…" : "Save Entry"}
                 </Button>
               </div>
 
@@ -490,7 +522,8 @@ const DashboardJournal = () => {
               />
 
               <p className="text-xs text-muted-foreground mt-2">
-                Your journal entries are saved locally on this device.
+                Your journal entries are saved to your account and sync across
+                devices.
               </p>
             </div>
           </div>

--- a/src/services/journal.ts
+++ b/src/services/journal.ts
@@ -1,0 +1,38 @@
+// =============================================================================
+// Dynasty Futures - Journal Service
+// =============================================================================
+// Maps to the backend's /v1/journal/* endpoints. Daily trader notes scoped to
+// one of the authenticated user's accounts. Persisted server-side so notes
+// follow the trader across devices (replaces the old localStorage-only store).
+// =============================================================================
+
+import { apiClient } from '@/services/api';
+import type { ApiResponse } from '@/types/api';
+
+export interface JournalEntry {
+  accountId: string;
+  date: string; // YYYY-MM-DD
+  content: string;
+}
+
+export const journalService = {
+  /**
+   * Get the entry for an account on a given day (content '' when empty).
+   * GET /v1/journal/:accountId/:date
+   */
+  get: (accountId: string, date: string): Promise<ApiResponse<JournalEntry>> =>
+    apiClient.get<ApiResponse<JournalEntry>>(`/journal/${accountId}/${date}`),
+
+  /**
+   * Create/update the entry (blank content clears it).
+   * PUT /v1/journal/:accountId/:date
+   */
+  save: (
+    accountId: string,
+    date: string,
+    content: string,
+  ): Promise<ApiResponse<JournalEntry>> =>
+    apiClient.put<ApiResponse<JournalEntry>>(`/journal/${accountId}/${date}`, {
+      content,
+    }),
+};


### PR DESCRIPTION
## What & why

Fixes two reported dashboard bugs and moves journal storage off the device, plus two small UI fixes.

### 1. Account selection persistence (bug fix)
Selecting an account didn't survive a refresh, and opening a calendar day loaded the **wrong** account's journal (it fell back to the first account in the list).

- New `useSelectedAccount` hook makes the `?account=` URL param + `localStorage` the single source of truth (resolution: URL → localStorage → first account), mirrored back to both. URL covers refresh + browser back/forward; localStorage covers param-less hops like the journal's "Back to Dashboard".
- `DashboardHome` and `DashboardJournal` share the selection.
- The Summary/Builder calendars and the journal's day-nav + "Back to Dashboard" now carry `?account=`, so **a calendar day opens that account's journal**.

### 2. Journal entries persisted in the DB (feature)
Journal notes were `localStorage`-only — lost on another device/browser. They now read/write the new `/v1/journal/:accountId/:date` API (see the backend PR), scoped per account + day, so notes follow the trader across devices. New `services/journal.ts` + `hooks/useJournal.ts` (query + mutation); the editor shows a saving state and seeds from the loaded entry.

> Behavior note: journal notes are now **per-account** (the old key was date-only, shared across accounts). Old device-local notes are not migrated — new entries write to the DB.

### 3. Small UI fixes
- Day-of-Week heatmap shows each day's P&L amount **always** (was hover-only).
- Max-loss chart badge raised (`bottom-8` → `bottom-14`) so it no longer collides with the X-axis labels.

## Testing
- `npm run build` clean (11 routes prerender); lint at the existing baseline.
- Live round-trip against the local API verified: save → reload → persisted; blank → cleared.

## Depends on
DF-Backend journal API PR (the `/v1/journal` endpoints + `JournalEntry` table). Requires `prisma migrate deploy` in prod (plain new table, non-destructive).
