### PR TITLE
Reorder dashboard sidebar; remove Pricing link

### DIFF
--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -7,17 +7,18 @@ import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 /** Same asset as <link rel="icon"> in index.html */
 const siteIconSrc = '/favicon.png?v=20260406';
 
+// Order mirrors the desktop sidebar: primary items first, then Profile /
+// Affiliate / Help Center. 'Trade' stays hidden (launch via the "Launch
+// Platform" button); its route + page are kept for later.
 const sidebarLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Wallet },
-  // 'Trade' tab hidden until the in-app Volumetrica embed is unblocked; traders
-  // launch via the "Launch Platform" button. Route + page kept for later.
-  { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
   { name: 'Billing', path: '/dashboard/billing', icon: CreditCard },
   { name: 'Payouts', path: '/dashboard/payouts', icon: Banknote },
-  { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
-  { name: 'Profile', path: '/dashboard/profile', icon: User },
   { name: 'Awards', path: '/dashboard/awards', icon: Trophy },
+  { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
+  { name: 'Profile', path: '/dashboard/profile', icon: User },
+  { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
   { name: 'Help Center', path: '/dashboard/help', icon: HelpCircle },
 ];
 

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -9,25 +9,28 @@ import {
   User,
   Award,
   Headphones,
-  Tag,
   ExternalLink,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const siteIconSrc = '/favicon.png?v=20260406';
 
-const sidebarLinks = [
+// Primary nav (top). 'Trade' stays hidden until the in-app Volumetrica embed is
+// unblocked — traders launch via the "Launch Platform" button. The
+// /dashboard/trade route + page are intentionally kept for when the embed works.
+const primaryLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: Activity },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Briefcase },
-  // 'Trade' tab is hidden until the in-app Volumetrica embed is unblocked — for
-  // now traders launch the platform via the "Launch Platform" button. The
-  // /dashboard/trade route + page are intentionally kept for when the embed works.
-  { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
   { name: 'Billing', path: '/dashboard/billing', icon: Receipt },
   { name: 'Payouts', path: '/dashboard/payouts', icon: ArrowDownToLine },
-  { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
-  { name: 'Profile', path: '/dashboard/profile', icon: User },
   { name: 'Awards', path: '/dashboard/awards', icon: Award },
+  { name: 'Economic Calendar', path: '/dashboard/economic-calendar', icon: CalendarClock },
+];
+
+// Secondary nav, pinned to the bottom of the sidebar.
+const secondaryLinks = [
+  { name: 'Profile', path: '/dashboard/profile', icon: User },
+  { name: 'Affiliate', path: '/dashboard/affiliate', icon: Users },
   { name: 'Help Center', path: '/dashboard/help', icon: Headphones },
 ];
 
@@ -39,6 +42,29 @@ const DashboardSidebar = () => {
       return location.pathname === '/dashboard';
     }
     return location.pathname.startsWith(path);
+  };
+
+  const renderLink = (link: { name: string; path: string; icon: typeof Activity }) => {
+    const Icon = link.icon;
+    const active = isActive(link.path);
+    return (
+      <Link
+        key={link.path}
+        to={link.path}
+        className={cn(
+          'flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all duration-300',
+          active
+            ? 'bg-primary/10 text-primary border border-primary/20'
+            : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+        )}
+      >
+        <Icon
+          size={18}
+          className={cn('shrink-0 transition-colors duration-300', active ? 'text-primary' : '')}
+        />
+        <span className="text-sm font-medium truncate">{link.name}</span>
+      </Link>
+    );
   };
 
   return (
@@ -63,43 +89,15 @@ const DashboardSidebar = () => {
         </a>
       </div>
 
-      {/* Navigation */}
+      {/* Primary navigation */}
       <nav className="flex-1 p-3 space-y-0.5 overflow-y-auto">
-        {sidebarLinks.map((link) => {
-          const Icon = link.icon;
-          const active = isActive(link.path);
-
-          return (
-            <Link
-              key={link.path}
-              to={link.path}
-              className={cn(
-                'flex items-center gap-3 px-3 py-2.5 rounded-xl transition-all duration-300',
-                active
-                  ? 'bg-primary/10 text-primary border border-primary/20'
-                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-              )}
-            >
-              <Icon
-                size={18}
-                className={cn('shrink-0 transition-colors duration-300', active ? 'text-primary' : '')}
-              />
-              <span className="text-sm font-medium truncate">{link.name}</span>
-            </Link>
-          );
-        })}
-
-        {/* Pricing — external link */}
-        <a
-          href="https://www.dynastyfuturesdyn.com/pricing"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-3 px-3 py-2.5 rounded-xl text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-all duration-300"
-        >
-          <Tag size={18} className="shrink-0" />
-          <span className="text-sm font-medium">Pricing</span>
-        </a>
+        {primaryLinks.map(renderLink)}
       </nav>
+
+      {/* Secondary navigation — pinned to the bottom */}
+      <div className="p-3 border-t border-border/30 space-y-0.5">
+        {secondaryLinks.map(renderLink)}
+      </div>
 
       {/* Footer */}
       <div className="p-3 border-t border-border/30">


### PR DESCRIPTION
Small dashboard-nav reorganization.

- **Primary nav (top):** Dashboard → Accounts → Billing → Payouts → Awards → Economic Calendar
- **Secondary nav (pinned to the bottom of the sidebar):** Profile → Affiliate → Help Center
- **Removed** the external **Pricing** link.
- Mobile nav (`DashboardMobileNav`) mirrors the same order.

`npm run build` clean (11 routes prerender); lint at the existing baseline. No route/page changes — nav links only.
