### PR TITLE
Dashboard fixes: trade log, real instrument breakdown, calendar + mobile polish

### DIFF
--- a/src/components/dashboard/AccountMetrics.tsx
+++ b/src/components/dashboard/AccountMetrics.tsx
@@ -15,7 +15,9 @@ import {
   Moon,
   Coffee,
 } from "lucide-react";
+import { useMemo } from "react";
 import { useAccountView } from "@/hooks/useAccountView";
+import { useAccountTrades } from "@/hooks/useTrading";
 import { EMPTY_ACCOUNT_DATA } from "@/lib/emptyAccountData";
 import {
   PieChart,
@@ -55,9 +57,96 @@ const SESSION_TIMES = {
   afternoon: "2:00-4:00",
 };
 
+const toNum = (v: string | number | null | undefined): number => {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+// Symbols arrive like "ES.CME" / "MNQ.CME"; color by the root ticker.
+const colorForSymbol = (name: string): string => {
+  const root = name.split(/[.\-/]/)[0]?.toUpperCase() ?? name;
+  return (
+    INSTRUMENT_COLORS[root as keyof typeof INSTRUMENT_COLORS] ||
+    "hsl(var(--muted-foreground))"
+  );
+};
+
+const fmtDuration = (mins: number): string => {
+  if (mins <= 0) return "—";
+  if (mins < 60) return `${Math.round(mins)}m`;
+  const h = Math.floor(mins / 60);
+  const m = Math.round(mins % 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+};
+
 const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
   const { data: rawAccountData } = useAccountView(accountId);
   const accountData = rawAccountData ?? EMPTY_ACCOUNT_DATA;
+  const { data: tradesData } = useAccountTrades(accountId || undefined);
+  const trades = useMemo(() => tradesData?.data ?? [], [tradesData]);
+
+  // Derive instrument breakdown, trade direction, and avg duration from real
+  // closed trades (commission-netted, consistent with the rest of the dashboard).
+  const derived = useMemo(() => {
+    const closed = trades.filter((t) => t.exitTime && t.realizedPnl !== null);
+    const net = (t: (typeof closed)[number]) =>
+      toNum(t.realizedPnl) - toNum(t.commission);
+
+    const bySymbol = new Map<
+      string,
+      { name: string; trades: number; wins: number; pnl: number }
+    >();
+    for (const t of closed) {
+      const g = bySymbol.get(t.symbol) ?? {
+        name: t.symbol,
+        trades: 0,
+        wins: 0,
+        pnl: 0,
+      };
+      const p = net(t);
+      g.trades += 1;
+      g.pnl += p;
+      if (p > 0) g.wins += 1;
+      bySymbol.set(t.symbol, g);
+    }
+
+    const breakdown = Array.from(bySymbol.values())
+      .map((g) => ({
+        name: g.name,
+        trades: g.trades,
+        winRate: g.trades ? Math.round((g.wins / g.trades) * 100) : 0,
+        pnl: g.pnl,
+        avgPnl: g.trades ? g.pnl / g.trades : 0,
+      }))
+      .sort((a, b) => b.trades - a.trades);
+
+    const longs = closed.filter((t) => t.side === "BUY").length;
+    const total = closed.length;
+    const durations = closed
+      .map((t) =>
+        t.exitTime
+          ? (new Date(t.exitTime).getTime() - new Date(t.entryTime).getTime()) /
+            60000
+          : 0,
+      )
+      .filter((d) => d > 0);
+
+    return {
+      breakdown,
+      totalTrades: total,
+      totalPnl: closed.reduce((s, t) => s + net(t), 0),
+      tradeDirection: total
+        ? {
+            long: Math.round((longs / total) * 100),
+            short: Math.round(((total - longs) / total) * 100),
+          }
+        : { long: 0, short: 0 },
+      avgDurationMin: durations.length
+        ? durations.reduce((a, b) => a + b, 0) / durations.length
+        : 0,
+    };
+  }, [trades]);
 
   const formatCurrency = (value: number, showSign = false) => {
     const formatted = `$${Math.abs(value).toLocaleString()}`;
@@ -93,18 +182,17 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
 
   const bestSession = sessionData.reduce((a, b) => (a.value > b.value ? a : b));
 
-  // TODO: replace with real instrument breakdown from CRM/broker API
-  const instrumentBreakdown: Array<{name: string; trades: number; winRate: number; pnl: number; avgPnl: number}> = [];
+  const instrumentBreakdown = derived.breakdown;
+  const totalTrades = derived.totalTrades;
+  const totalPnl = derived.totalPnl;
 
-  const totalTrades = 0;
-  const totalPnl = 0;
-
-  const sortedByWinRate = [...instrumentBreakdown];
+  const sortedByWinRate = [...instrumentBreakdown].sort(
+    (a, b) => b.winRate - a.winRate,
+  );
   const hasInstrumentData = instrumentBreakdown.length > 0;
 
-  // TODO: derive from real trade data
-  const tradeDirection = { long: 0, short: 0 };
-  const hasTradeDirection = tradeDirection.long > 0 || tradeDirection.short > 0;
+  const tradeDirection = derived.tradeDirection;
+  const hasTradeDirection = totalTrades > 0;
 
   // Get color for profit factor
   const getProfitFactorColor = () => {
@@ -162,7 +250,11 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                 Avg. Duration
               </span>
             </div>
-            <span className="text-lg font-bold text-foreground">—</span>
+            <span className="text-lg font-bold text-foreground">
+              {derived.avgDurationMin > 0
+                ? fmtDuration(derived.avgDurationMin)
+                : "—"}
+            </span>
           </div>
         </div>
       </div>
@@ -390,7 +482,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                         {instrumentBreakdown.map((entry) => (
                           <Cell
                             key={entry.name}
-                            fill={INSTRUMENT_COLORS[entry.name as keyof typeof INSTRUMENT_COLORS] || "hsl(var(--muted-foreground))"}
+                            fill={colorForSymbol(entry.name)}
                           />
                         ))}
                       </Pie>
@@ -405,11 +497,11 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                   {instrumentBreakdown.map((inst) => (
                     <div key={inst.name} className="flex items-center gap-3">
                       <div className="flex items-center gap-2 min-w-[50px]">
-                        <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: INSTRUMENT_COLORS[inst.name as keyof typeof INSTRUMENT_COLORS] }} />
+                        <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: colorForSymbol(inst.name) }} />
                         <span className="text-xs font-medium text-foreground">{inst.name}</span>
                       </div>
                       <div className="flex-1 h-2 rounded-full bg-muted/20 overflow-hidden">
-                        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${(inst.trades / totalTrades) * 100}%`, backgroundColor: INSTRUMENT_COLORS[inst.name as keyof typeof INSTRUMENT_COLORS] }} />
+                        <div className="h-full rounded-full transition-all duration-500" style={{ width: `${(inst.trades / totalTrades) * 100}%`, backgroundColor: colorForSymbol(inst.name) }} />
                       </div>
                       <span className="text-[10px] text-muted-foreground min-w-[45px] text-right">{inst.trades} trades</span>
                     </div>
@@ -429,7 +521,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                   {sortedByWinRate.map((inst, index) => (
                     <div key={inst.name} className="flex items-center gap-3">
                       <div className="flex items-center gap-2 min-w-[50px]">
-                        <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: INSTRUMENT_COLORS[inst.name as keyof typeof INSTRUMENT_COLORS] }} />
+                        <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: colorForSymbol(inst.name) }} />
                         <span className="text-xs font-medium text-foreground">{inst.name}</span>
                       </div>
                       <div className="flex-1 h-3 rounded-full bg-muted/20 overflow-hidden">
@@ -459,7 +551,7 @@ const AccountMetrics = ({ accountId }: AccountMetricsProps) => {
                   {instrumentBreakdown.map((inst) => (
                     <div key={inst.name} className="p-3 rounded-lg bg-muted/10 border border-border/20 flex items-center justify-between">
                       <div className="flex items-center gap-2">
-                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: INSTRUMENT_COLORS[inst.name as keyof typeof INSTRUMENT_COLORS] }} />
+                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: colorForSymbol(inst.name) }} />
                         <span className="text-sm font-medium text-foreground">{inst.name}</span>
                       </div>
                       <div className="text-right">

--- a/src/components/dashboard/AccountSelector.tsx
+++ b/src/components/dashboard/AccountSelector.tsx
@@ -28,7 +28,7 @@ const AccountSelector = ({ value, onValueChange }: AccountSelectorProps) => {
 
   return (
     <Select value={value} onValueChange={onValueChange}>
-      <SelectTrigger className="w-[300px] bg-card/50 border-border/30 backdrop-blur-sm rounded-xl h-11">
+      <SelectTrigger className="w-full sm:w-[300px] bg-card/50 border-border/30 backdrop-blur-sm rounded-xl h-11">
         <SelectValue
           placeholder={isLoading ? 'Loading accounts…' : 'Select account'}
         />

--- a/src/components/dashboard/AccountTradeLog.tsx
+++ b/src/components/dashboard/AccountTradeLog.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from "react";
+import { Clock, Loader2, ListOrdered } from "lucide-react";
+import { differenceInMinutes } from "date-fns";
+import { cn } from "@/lib/utils";
+import { useAccountTrades } from "@/hooks/useTrading";
+
+interface AccountTradeLogProps {
+  accountId: string;
+}
+
+const toNum = (v: string | number | null | undefined): number => {
+  if (v === null || v === undefined) return 0;
+  const n = typeof v === "number" ? v : parseFloat(v);
+  return Number.isFinite(n) ? n : 0;
+};
+
+const fmtCurrency = (value: number): string => {
+  const formatted = `$${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
+  return value < 0 ? `-${formatted}` : `+${formatted}`;
+};
+
+const fmtDateTime = (iso: string): string =>
+  new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+
+const fmtDuration = (entryIso: string, exitIso: string | null): string => {
+  if (!exitIso) return "Open";
+  const mins = differenceInMinutes(new Date(exitIso), new Date(entryIso));
+  if (mins < 1) return "<1m";
+  if (mins >= 60) {
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    return m > 0 ? `${h}h ${m}m` : `${h}h`;
+  }
+  return `${mins}m`;
+};
+
+/**
+ * Account-wide trade log — every trade taken on the selected account (most
+ * recent first), net of commission. Distinct from the journal's per-day log.
+ */
+const AccountTradeLog = ({ accountId }: AccountTradeLogProps) => {
+  const { data, isLoading } = useAccountTrades(accountId || undefined);
+
+  const trades = useMemo(() => {
+    const all = data?.data ?? [];
+    return [...all].sort(
+      (a, b) =>
+        new Date(b.exitTime ?? b.entryTime).getTime() -
+        new Date(a.exitTime ?? a.entryTime).getTime(),
+    );
+  }, [data]);
+
+  return (
+    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
+      <div className="p-5 border-b border-border/30 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ListOrdered size={18} className="text-gold-dark" />
+          <h3 className="text-base font-semibold text-foreground">Trade Log</h3>
+        </div>
+        {trades.length > 0 && (
+          <span className="text-[11px] font-medium text-foreground bg-primary/10 px-2 py-0.5 rounded-full border border-primary/20">
+            {trades.length} {trades.length === 1 ? "trade" : "trades"}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground gap-2">
+          <Loader2 className="animate-spin" size={18} /> Loading trades…
+        </div>
+      ) : trades.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+          <Clock size={28} className="mb-2 opacity-40" />
+          <p className="text-sm">No trades on this account yet</p>
+        </div>
+      ) : (
+        <div className="max-h-[420px] overflow-auto">
+          <table className="w-full text-sm">
+            <thead className="sticky top-0 bg-card/95 backdrop-blur-sm z-10">
+              <tr className="border-b border-border/30">
+                {[
+                  "Date",
+                  "Symbol",
+                  "Side",
+                  "Qty",
+                  "Entry",
+                  "Exit",
+                  "Duration",
+                ].map((h) => (
+                  <th
+                    key={h}
+                    className="text-left py-2.5 px-3 text-xs text-muted-foreground font-medium whitespace-nowrap"
+                  >
+                    {h}
+                  </th>
+                ))}
+                <th className="text-right py-2.5 px-3 text-xs text-muted-foreground font-medium">
+                  P&L
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {trades.map((trade, i) => {
+                const direction = trade.side === "BUY" ? "Long" : "Short";
+                const pnl = toNum(trade.realizedPnl) - toNum(trade.commission);
+                return (
+                  <tr
+                    key={trade.id}
+                    className={cn(
+                      "border-b border-border/10 hover:bg-muted/10 transition-colors",
+                      i % 2 === 1 && "bg-muted/[0.03]",
+                    )}
+                  >
+                    <td className="py-2.5 px-3 text-foreground text-xs whitespace-nowrap">
+                      {fmtDateTime(trade.exitTime ?? trade.entryTime)}
+                    </td>
+                    <td className="py-2.5 px-3 text-foreground font-medium">
+                      {trade.symbol}
+                    </td>
+                    <td className="py-2.5 px-3">
+                      <span
+                        className={cn(
+                          "text-xs font-medium px-1.5 py-0.5 rounded",
+                          direction === "Long"
+                            ? "text-emerald-500 bg-emerald-500/10"
+                            : "text-destructive bg-destructive/10",
+                        )}
+                      >
+                        {direction}
+                      </span>
+                    </td>
+                    <td className="py-2.5 px-3 text-muted-foreground text-xs">
+                      {trade.quantity}
+                    </td>
+                    <td className="py-2.5 px-3 text-muted-foreground text-xs">
+                      {toNum(trade.entryPrice).toFixed(2)}
+                    </td>
+                    <td className="py-2.5 px-3 text-muted-foreground text-xs">
+                      {trade.exitPrice ? toNum(trade.exitPrice).toFixed(2) : "—"}
+                    </td>
+                    <td className="py-2.5 px-3 text-muted-foreground text-xs whitespace-nowrap">
+                      {fmtDuration(trade.entryTime, trade.exitTime)}
+                    </td>
+                    <td
+                      className={cn(
+                        "py-2.5 px-3 text-right font-semibold text-xs whitespace-nowrap",
+                        trade.realizedPnl === null
+                          ? "text-muted-foreground"
+                          : pnl >= 0
+                            ? "text-emerald-500"
+                            : "text-destructive",
+                      )}
+                    >
+                      {trade.realizedPnl !== null ? fmtCurrency(pnl) : "—"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AccountTradeLog;

--- a/src/components/dashboard/BuilderPanel.tsx
+++ b/src/components/dashboard/BuilderPanel.tsx
@@ -350,7 +350,7 @@ const BuilderPanel = ({
                 >
                   <span
                     className={cn(
-                      "font-medium leading-none",
+                      "text-[11px] sm:text-xs font-medium leading-none",
                       day.isSelected && !day.isSaturday && "text-primary",
                       !day.isCurrentMonth && "text-muted-foreground/50",
                       day.isSaturday && day.isCurrentMonth && "text-muted-foreground/30",
@@ -362,7 +362,7 @@ const BuilderPanel = ({
                   {day.isCurrentMonth && !day.noTrades && !day.isSaturday && (
                     <span
                       className={cn(
-                        "text-[8px] font-semibold leading-none mt-0.5",
+                        "text-[10px] sm:text-xs font-semibold leading-none mt-1",
                         day.pnl > 0 ? "text-emerald-500" : "text-destructive",
                       )}
                     >
@@ -528,9 +528,9 @@ const BuilderPanel = ({
                   const getHeatmapColor = () => {
                     if (value === 0) return "bg-muted/30";
                     if (value > 0) {
-                      if (intensity > 0.7) return "bg-primary";
-                      if (intensity > 0.4) return "bg-primary/70";
-                      return "bg-primary/40";
+                      if (intensity > 0.7) return "bg-emerald-500";
+                      if (intensity > 0.4) return "bg-emerald-500/70";
+                      return "bg-emerald-500/40";
                     } else {
                       if (intensity > 0.7) return "bg-destructive";
                       if (intensity > 0.4) return "bg-destructive/70";
@@ -550,8 +550,7 @@ const BuilderPanel = ({
                         ).toLocaleString()}`}
                       >
                         <span className="text-[10px] font-medium text-foreground/90">
-                          {value >= 0 ? "+" : "-"}$
-                          {Math.abs(value).toLocaleString()}
+                          {value === 0 ? "$0" : fmtDayPnl(value)}
                         </span>
                       </div>
                       <span className="text-[10px] text-muted-foreground mt-1 block">
@@ -574,7 +573,7 @@ const BuilderPanel = ({
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded bg-primary" />
+                <div className="w-3 h-3 rounded bg-emerald-500" />
                 <span className="text-[9px] text-muted-foreground">Profit</span>
               </div>
             </div>

--- a/src/components/dashboard/ResetAccountModal.tsx
+++ b/src/components/dashboard/ResetAccountModal.tsx
@@ -1,0 +1,177 @@
+import { Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+// =============================================================================
+// Reset Account modal (shared by the Accounts page + the dashboard)
+// =============================================================================
+// Paid account resets are GATED: YPF has not configured reset checkout URLs /
+// products yet (probe 2026-06-27 found 0/27 programs with an accountResetUrl,
+// and the direct checkout-reset API resets without payment). So this surfaces
+// the reset price + a "coming soon" state instead of a dead-end action. Flip
+// `RESET_ENABLED` + wire the checkout link once YPF provides it.
+// =============================================================================
+
+const RESET_ENABLED = false;
+
+type PlanKey = "standard" | "advanced" | "builder";
+type SizeKey = "25k" | "50k" | "100k" | "150k";
+
+interface ResetPricing {
+  evalReset: number;
+  fundedReset: number;
+}
+
+// TODO: replace with real pricing once the YPF reset checkout is available.
+const RESET_PRICING: Record<PlanKey, Record<SizeKey, ResetPricing>> = {
+  standard: {
+    "25k": { evalReset: 30, fundedReset: 119 },
+    "50k": { evalReset: 40, fundedReset: 159 },
+    "100k": { evalReset: 65, fundedReset: 259 },
+    "150k": { evalReset: 80, fundedReset: 319 },
+  },
+  advanced: {
+    "25k": { evalReset: 40, fundedReset: 159 },
+    "50k": { evalReset: 55, fundedReset: 219 },
+    "100k": { evalReset: 90, fundedReset: 359 },
+    "150k": { evalReset: 115, fundedReset: 459 },
+  },
+  builder: {
+    "25k": { evalReset: 55, fundedReset: 219 },
+    "50k": { evalReset: 75, fundedReset: 299 },
+    "100k": { evalReset: 120, fundedReset: 479 },
+    "150k": { evalReset: 150, fundedReset: 599 },
+  },
+};
+
+const resolvePlanKey = (planType: string): PlanKey => {
+  const lc = planType.toLowerCase();
+  if (lc.includes("builder") || lc.includes("dynasty")) return "builder";
+  if (lc.includes("advanced")) return "advanced";
+  return "standard";
+};
+
+const resolveSizeKey = (rawSize: number): SizeKey => {
+  if (rawSize <= 25000) return "25k";
+  if (rawSize <= 50000) return "50k";
+  if (rawSize <= 100000) return "100k";
+  return "150k";
+};
+
+interface ResetPriceInfo {
+  price: number;
+  resetType: "Evaluation Reset" | "Funded Reset";
+}
+
+const getResetPriceInfo = (
+  planType: string,
+  accountSizeUsd: number,
+  isFunded: boolean,
+): ResetPriceInfo | null => {
+  if (!Number.isFinite(accountSizeUsd) || accountSizeUsd <= 0) return null;
+  const pricing =
+    RESET_PRICING[resolvePlanKey(planType)]?.[resolveSizeKey(accountSizeUsd)];
+  if (!pricing) return null;
+  return {
+    price: isFunded ? pricing.fundedReset : pricing.evalReset,
+    resetType: isFunded ? "Funded Reset" : "Evaluation Reset",
+  };
+};
+
+export interface ResetAccountTarget {
+  planType: string;
+  accountSizeUsd: number;
+  isFunded: boolean;
+}
+
+interface ResetAccountModalProps {
+  account: ResetAccountTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const ResetAccountModal = ({
+  account,
+  open,
+  onOpenChange,
+}: ResetAccountModalProps) => {
+  const priceInfo = account
+    ? getResetPriceInfo(account.planType, account.accountSizeUsd, account.isFunded)
+    : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reset Account</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-4 pt-1">
+              {account && (
+                <>
+                  <div className="rounded-xl border border-border/30 bg-muted/20 p-4 space-y-2 text-sm">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Account</span>
+                      <span className="text-foreground font-medium">
+                        {new Intl.NumberFormat("en-US", {
+                          style: "currency",
+                          currency: "USD",
+                          maximumFractionDigits: 0,
+                        }).format(account.accountSizeUsd)}{" "}
+                        {account.planType}
+                      </span>
+                    </div>
+                    {priceInfo && (
+                      <>
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Reset Type</span>
+                          <span className="text-foreground">
+                            {priceInfo.resetType}
+                          </span>
+                        </div>
+                        <div className="flex justify-between border-t border-border/20 pt-2 mt-2">
+                          <span className="text-muted-foreground">Reset Price</span>
+                          <span className="text-foreground font-semibold">
+                            ${priceInfo.price.toLocaleString()}
+                          </span>
+                        </div>
+                      </>
+                    )}
+                  </div>
+
+                  <div className="flex items-start gap-2 rounded-xl border border-primary/20 bg-primary/5 p-3">
+                    <Clock
+                      size={16}
+                      className="text-primary flex-shrink-0 mt-0.5"
+                    />
+                    <p className="text-sm text-muted-foreground">
+                      Account resets are coming soon. You'll be able to reset this
+                      account and start a fresh evaluation in the same program
+                      directly from here.
+                    </p>
+                  </div>
+                </>
+              )}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+          <Button disabled={!RESET_ENABLED}>
+            {RESET_ENABLED ? "Continue to Reset" : "Coming Soon"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ResetAccountModal;

--- a/src/components/dashboard/SummaryPanel.tsx
+++ b/src/components/dashboard/SummaryPanel.tsx
@@ -351,12 +351,14 @@ const SummaryPanel = ({
                   </div>
                   <div className="space-y-1.5">
                     <div className="flex items-center justify-between gap-2">
-                      <span className="text-xs text-muted-foreground">Login</span>
+                      <span className="text-xs text-muted-foreground flex-shrink-0">
+                        Login
+                      </span>
                       <button
                         onClick={() =>
                           copyToClipboard(account.credentials!.login, "Login")
                         }
-                        className="text-xs font-mono text-foreground hover:text-primary transition-colors"
+                        className="text-xs font-mono text-foreground hover:text-primary transition-colors truncate min-w-0 text-right"
                         title="Click to copy"
                       >
                         {account.credentials.login}
@@ -465,7 +467,7 @@ const SummaryPanel = ({
                 >
                   <span
                     className={cn(
-                      "font-medium leading-none",
+                      "text-[11px] sm:text-xs font-medium leading-none",
                       day.isSelected && !day.isSaturday && "text-primary",
                       !day.isCurrentMonth && "text-muted-foreground/50",
                       day.isSaturday && day.isCurrentMonth && "text-muted-foreground/30",
@@ -478,7 +480,7 @@ const SummaryPanel = ({
                   {day.isCurrentMonth && !day.noTrades && !day.isSaturday && (
                     <span
                       className={cn(
-                        "text-[8px] font-semibold leading-none mt-0.5",
+                        "text-[10px] sm:text-xs font-semibold leading-none mt-1",
                         day.pnl > 0 ? "text-emerald-500" : "text-destructive",
                       )}
                     >
@@ -644,9 +646,9 @@ const SummaryPanel = ({
                   const getHeatmapColor = () => {
                     if (value === 0) return "bg-muted/30";
                     if (value > 0) {
-                      if (intensity > 0.7) return "bg-primary";
-                      if (intensity > 0.4) return "bg-primary/70";
-                      return "bg-primary/40";
+                      if (intensity > 0.7) return "bg-emerald-500";
+                      if (intensity > 0.4) return "bg-emerald-500/70";
+                      return "bg-emerald-500/40";
                     } else {
                       if (intensity > 0.7) return "bg-destructive";
                       if (intensity > 0.4) return "bg-destructive/70";
@@ -666,8 +668,7 @@ const SummaryPanel = ({
                         ).toLocaleString()}`}
                       >
                         <span className="text-[10px] font-medium text-foreground/90">
-                          {value >= 0 ? "+" : "-"}$
-                          {Math.abs(value).toLocaleString()}
+                          {value === 0 ? "$0" : fmtDayPnl(value)}
                         </span>
                       </div>
                       <span className="text-[10px] text-muted-foreground mt-1 block">
@@ -690,7 +691,7 @@ const SummaryPanel = ({
                 </span>
               </div>
               <div className="flex items-center gap-1.5">
-                <div className="w-3 h-3 rounded bg-primary" />
+                <div className="w-3 h-3 rounded bg-emerald-500" />
                 <span className="text-[9px] text-muted-foreground">Profit</span>
               </div>
             </div>

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -358,10 +358,20 @@ export const adaptAccountView = (
   const startingBalance = num(account.startingBalance);
   const currentBalance = num(account.currentBalance);
   const challenges = 'challenges' in account ? account.challenges : undefined;
-  const { profitTarget, maxDrawdown, dailyLossLimit } = challengeRules(
-    challenges,
-    startingBalance,
-  );
+  const plan = detectPlan(account);
+  const rules = challengeRules(challenges, startingBalance);
+  const { maxDrawdown, dailyLossLimit } = rules;
+  // A passed evaluation advances its challenge to the FUNDED phase, which carries
+  // a 0 profit target — so a passed/closed eval account would otherwise lose its
+  // target line entirely. Standard/Advanced are evaluation-based (~6% target), so
+  // fall back to that when the current challenge reports no target, keeping the
+  // (now-reached) target line on the chart. Builder/Dynasty are instant-funded
+  // and genuinely have no evaluation target → leave at 0 (no line).
+  const EVAL_TARGET_PCT = 6;
+  const profitTarget =
+    rules.profitTarget === 0 && (plan === 'Standard' || plan === 'Advanced')
+      ? (EVAL_TARGET_PCT / 100) * startingBalance
+      : rules.profitTarget;
 
   // Prefer real daily snapshots; fall back to a trade-derived series when the
   // backend has none (the common case, since YPF has no snapshot time series).
@@ -388,8 +398,8 @@ export const adaptAccountView = (
     id: account.id,
     name: account.accountType.displayName || account.accountType.name,
     size: num(account.accountType.accountSize, startingBalance),
-    plan: detectPlan(account),
-    planType: detectPlan(account),
+    plan,
+    planType: plan,
     stage: stageFor(account.status),
     status: uiStatusFor(account.status),
     startingBalance,

--- a/src/pages/dashboard/DashboardAccounts.tsx
+++ b/src/pages/dashboard/DashboardAccounts.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { Eye, ChevronRight, RotateCcw, AlertCircle, Loader2, Plus } from "lucide-react";
-import { toast } from "sonner";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,16 +10,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useTradingAccounts } from "@/hooks/useTrading";
+import ResetAccountModal, {
+  type ResetAccountTarget,
+} from "@/components/dashboard/ResetAccountModal";
 import type { TradingAccount, AccountStatus } from "@/types/trading";
 
 type StageLabel = "Evaluation" | "Funded" | "Closed";
@@ -31,6 +25,7 @@ interface AccountView {
   startDate: string;
   planType: string;
   accountSize: string;
+  accountSizeUsd: number;
   stage: StageLabel;
   status: StatusLabel;
   rawStatus: AccountStatus;
@@ -76,11 +71,15 @@ const toView = (a: TradingAccount): AccountView => ({
   startDate: fmtDate(a.activatedAt ?? a.createdAt),
   planType: a.accountType.displayName || a.accountType.name,
   accountSize: fmtUsd(a.accountType.accountSize),
+  accountSizeUsd: Number(a.accountType.accountSize) || 0,
   stage: STAGE_BY_STATUS[a.status],
   status: STATUS_LABEL_BY_STATUS[a.status],
   rawStatus: a.status,
   balance: fmtUsd(a.currentBalance),
-  isResettable: a.status === "EVALUATION" || a.status === "PHASE_2",
+  // Reset applies to violated (breached) accounts — restart the evaluation in
+  // the same program. Not active accounts (no reason to reset a live one) and
+  // not permanently CLOSED/disabled accounts (YPF won't reset those).
+  isResettable: a.status === "FAILED" || a.status === "SUSPENDED",
 });
 
 const getStatusBadge = (status: StatusLabel): string => {
@@ -101,86 +100,40 @@ const getStageBadge = (stage: StageLabel): string => {
   return styles[stage];
 };
 
-// =============================================================================
-// Reset pricing
-// TODO: Replace with real plan/size pricing data from CRM or pricing API once
-//       account billing integration is complete.
-// =============================================================================
-
-type PlanKey = "standard" | "advanced" | "builder";
-type SizeKey = "25k" | "50k" | "100k" | "150k";
-
-interface ResetPricing {
-  evalReset: number;
-  fundedReset: number;
-}
-
-const RESET_PRICING: Record<PlanKey, Record<SizeKey, ResetPricing>> = {
-  standard: {
-    "25k": { evalReset: 30, fundedReset: 119 },
-    "50k": { evalReset: 40, fundedReset: 159 },
-    "100k": { evalReset: 65, fundedReset: 259 },
-    "150k": { evalReset: 80, fundedReset: 319 },
-  },
-  advanced: {
-    "25k": { evalReset: 40, fundedReset: 159 },
-    "50k": { evalReset: 55, fundedReset: 219 },
-    "100k": { evalReset: 90, fundedReset: 359 },
-    "150k": { evalReset: 115, fundedReset: 459 },
-  },
-  builder: {
-    "25k": { evalReset: 55, fundedReset: 219 },
-    "50k": { evalReset: 75, fundedReset: 299 },
-    "100k": { evalReset: 120, fundedReset: 479 },
-    "150k": { evalReset: 150, fundedReset: 599 },
-  },
-};
-
-function resolvePlanKey(planType: string): PlanKey {
-  const lc = planType.toLowerCase();
-  if (lc.includes("builder")) return "builder";
-  if (lc.includes("advanced")) return "advanced";
-  return "standard";
-}
-
-function resolveSizeKey(rawSize: number): SizeKey {
-  if (rawSize <= 25000) return "25k";
-  if (rawSize <= 50000) return "50k";
-  if (rawSize <= 100000) return "100k";
-  return "150k";
-}
-
-interface ResetPriceInfo {
-  price: number;
-  resetType: "Evaluation Reset" | "Funded Reset";
-}
-
-function getResetPriceInfo(account: AccountView): ResetPriceInfo | null {
-  const planKey = resolvePlanKey(account.planType);
-  const rawSize = parseInt(account.accountSize.replace(/[^0-9]/g, ""), 10);
-  if (isNaN(rawSize) || rawSize === 0) return null;
-  const sizeKey = resolveSizeKey(rawSize);
-  const pricing = RESET_PRICING[planKey]?.[sizeKey];
-  if (!pricing) return null;
-  const isFunded = account.stage === "Funded";
-  return {
-    price: isFunded ? pricing.fundedReset : pricing.evalReset,
-    resetType: isFunded ? "Funded Reset" : "Evaluation Reset",
-  };
-}
-
-const truncateId = (id: string) => id.length > 12 ? `${id.slice(0, 8)}…` : id;
+const truncateId = (id: string) => (id.length > 12 ? `${id.slice(0, 8)}…` : id);
 
 // =============================================================================
 // Sub-components
 // =============================================================================
 
-interface ActiveAccountsTableProps {
-  accounts: AccountView[];
-  onReset: (account: AccountView) => void;
-}
+const ViewButton = ({ id }: { id: string }) => (
+  <Button
+    variant="outline"
+    size="sm"
+    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50 transition-all"
+    asChild
+  >
+    <Link to={`/dashboard?account=${id}`}>
+      <Eye size={16} className="mr-2" />
+      View
+      <ChevronRight size={14} className="ml-1" />
+    </Link>
+  </Button>
+);
 
-const ActiveAccountsTable = ({ accounts, onReset }: ActiveAccountsTableProps) => {
+const ResetButton = ({ onClick }: { onClick: () => void }) => (
+  <Button
+    variant="outline"
+    size="sm"
+    className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70 transition-all"
+    onClick={onClick}
+  >
+    <RotateCcw size={14} className="mr-2" />
+    Reset
+  </Button>
+);
+
+const ActiveAccountsTable = ({ accounts }: { accounts: AccountView[] }) => {
   if (accounts.length === 0) {
     return (
       <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-10 text-center text-muted-foreground">
@@ -191,7 +144,7 @@ const ActiveAccountsTable = ({ accounts, onReset }: ActiveAccountsTableProps) =>
   }
 
   return (
-    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
+    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
       <Table>
         <TableHeader>
           <TableRow className="border-border/30 hover:bg-transparent">
@@ -230,29 +183,7 @@ const ActiveAccountsTable = ({ accounts, onReset }: ActiveAccountsTableProps) =>
               <TableCell className="font-semibold text-foreground py-4">{account.balance}</TableCell>
               <TableCell className="text-right py-4">
                 <div className="flex items-center justify-end gap-2">
-                  {account.isResettable && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70 transition-all"
-                      onClick={() => onReset(account)}
-                    >
-                      <RotateCcw size={14} className="mr-2" />
-                      Reset
-                    </Button>
-                  )}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary/50 transition-all"
-                    asChild
-                  >
-                    <Link to={`/dashboard?account=${account.id}`}>
-                      <Eye size={16} className="mr-2" />
-                      View
-                      <ChevronRight size={14} className="ml-1" />
-                    </Link>
-                  </Button>
+                  <ViewButton id={account.id} />
                 </div>
               </TableCell>
             </TableRow>
@@ -265,9 +196,10 @@ const ActiveAccountsTable = ({ accounts, onReset }: ActiveAccountsTableProps) =>
 
 interface InactiveAccountsTableProps {
   accounts: AccountView[];
+  onReset: (account: AccountView) => void;
 }
 
-const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
+const InactiveAccountsTable = ({ accounts, onReset }: InactiveAccountsTableProps) => {
   if (accounts.length === 0) {
     return (
       <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 p-10 text-center text-muted-foreground">
@@ -278,7 +210,7 @@ const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
   }
 
   return (
-    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-hidden">
+    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
       <Table>
         <TableHeader>
           <TableRow className="border-border/30 hover:bg-transparent">
@@ -287,6 +219,7 @@ const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
             <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
             <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
             <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
+            <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -312,6 +245,14 @@ const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
                   {account.status}
                 </span>
               </TableCell>
+              <TableCell className="text-right py-4">
+                <div className="flex items-center justify-end gap-2">
+                  {account.isResettable && (
+                    <ResetButton onClick={() => onReset(account)} />
+                  )}
+                  <ViewButton id={account.id} />
+                </div>
+              </TableCell>
             </TableRow>
           ))}
         </TableBody>
@@ -327,7 +268,8 @@ const InactiveAccountsTable = ({ accounts }: InactiveAccountsTableProps) => {
 const DashboardAccounts = () => {
   const { data, isLoading, isError, error } = useTradingAccounts();
 
-  const [resetModalAccount, setResetModalAccount] = useState<AccountView | null>(null);
+  const [resetTarget, setResetTarget] = useState<ResetAccountTarget | null>(null);
+  const [resetOpen, setResetOpen] = useState(false);
 
   const accounts = useMemo<AccountView[]>(
     () => (data?.data ?? []).map(toView),
@@ -344,17 +286,14 @@ const DashboardAccounts = () => {
     [accounts],
   );
 
-  const openResetModal = (account: AccountView) => setResetModalAccount(account);
-  const closeResetModal = () => setResetModalAccount(null);
-
-  // TODO: Connect to CRM account lookup, billing/checkout, and account reset
-  //       API once integration is complete.
-  const handleContinueToReset = () => {
-    toast.info("Reset checkout will be available once account billing is connected.");
-    closeResetModal();
+  const openReset = (account: AccountView) => {
+    setResetTarget({
+      planType: account.planType,
+      accountSizeUsd: account.accountSizeUsd,
+      isFunded: account.stage === "Funded",
+    });
+    setResetOpen(true);
   };
-
-  const resetPriceInfo = resetModalAccount ? getResetPriceInfo(resetModalAccount) : null;
 
   return (
     <div className="space-y-10 pt-16 lg:pt-0">
@@ -406,7 +345,7 @@ const DashboardAccounts = () => {
               </span>
             )}
           </div>
-          <ActiveAccountsTable accounts={activeAccounts} onReset={openResetModal} />
+          <ActiveAccountsTable accounts={activeAccounts} />
         </ScrollReveal>
       )}
 
@@ -422,62 +361,15 @@ const DashboardAccounts = () => {
               </span>
             )}
           </div>
-          <InactiveAccountsTable accounts={inactiveAccounts} />
+          <InactiveAccountsTable accounts={inactiveAccounts} onReset={openReset} />
         </ScrollReveal>
       )}
 
-      {/* Reset Account confirmation modal */}
-      <Dialog open={resetModalAccount !== null} onOpenChange={(open) => !open && closeResetModal()}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Reset Account</DialogTitle>
-            <DialogDescription asChild>
-              <div className="space-y-4 pt-1">
-                {resetModalAccount && (
-                  <>
-                    <div className="rounded-xl border border-border/30 bg-muted/20 p-4 space-y-2 text-sm">
-                      <div className="flex justify-between">
-                        <span className="text-muted-foreground">Account</span>
-                        <span className="text-foreground font-medium">
-                          {resetModalAccount.accountSize} {resetModalAccount.planType}
-                        </span>
-                      </div>
-                      <div className="flex justify-between">
-                        <span className="text-muted-foreground">Stage</span>
-                        <span className="text-foreground">{resetModalAccount.stage}</span>
-                      </div>
-                      {resetPriceInfo && (
-                        <>
-                          <div className="flex justify-between">
-                            <span className="text-muted-foreground">Reset Type</span>
-                            <span className="text-foreground">{resetPriceInfo.resetType}</span>
-                          </div>
-                          <div className="flex justify-between border-t border-border/20 pt-2 mt-2">
-                            <span className="text-muted-foreground">Reset Price</span>
-                            <span className="text-foreground font-semibold">
-                              ${resetPriceInfo.price.toLocaleString()}
-                            </span>
-                          </div>
-                        </>
-                      )}
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Resetting this account will require a reset purchase.
-                      {resetPriceInfo
-                        ? ` The reset price for this account is $${resetPriceInfo.price.toLocaleString()}.`
-                        : " Reset pricing will be calculated at checkout."}
-                    </p>
-                  </>
-                )}
-              </div>
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="gap-2 sm:gap-2">
-            <Button variant="outline" onClick={closeResetModal}>Cancel</Button>
-            <Button onClick={handleContinueToReset}>Continue to Reset</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ResetAccountModal
+        account={resetTarget}
+        open={resetOpen}
+        onOpenChange={setResetOpen}
+      />
     </div>
   );
 };

--- a/src/pages/dashboard/DashboardAffiliate.tsx
+++ b/src/pages/dashboard/DashboardAffiliate.tsx
@@ -834,22 +834,22 @@ const DashboardAffiliate = () => {
                 Our affiliate support team is here for you.
               </p>
             </div>
-            <div className="flex flex-col sm:flex-row gap-3">
+            <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
               <Button
                 onClick={() =>
                   (window.location.href =
                     "mailto:affiliates@dynastyfuturesdyn.com")
                 }
-                className="bg-primary hover:bg-primary/90 text-primary-foreground"
+                className="bg-primary hover:bg-primary/90 text-primary-foreground h-auto min-h-10 whitespace-normal break-all text-center"
               >
-                <Mail size={16} className="mr-2" />
+                <Mail size={16} className="mr-2 flex-shrink-0" />
                 affiliates@dynastyfuturesdyn.com
               </Button>
               <Button
                 variant="outline"
                 className="border-border/30 hover:bg-card/70"
               >
-                <MessageCircle size={16} className="mr-2" />
+                <MessageCircle size={16} className="mr-2 flex-shrink-0" />
                 Open Support Ticket
               </Button>
             </div>

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -11,6 +11,7 @@ import {
   Loader2,
   AlertCircle,
   Plus,
+  RotateCcw,
 } from "lucide-react";
 import { format, isToday } from "date-fns";
 import { toast } from "sonner";
@@ -22,7 +23,11 @@ import PerformanceChart from "@/components/dashboard/PerformanceChart";
 import SummaryPanel from "@/components/dashboard/SummaryPanel";
 import BuilderPanel from "@/components/dashboard/BuilderPanel";
 import AccountMetrics from "@/components/dashboard/AccountMetrics";
+import AccountTradeLog from "@/components/dashboard/AccountTradeLog";
 import DailyAnalytics from "@/components/dashboard/DailyAnalytics";
+import ResetAccountModal, {
+  type ResetAccountTarget,
+} from "@/components/dashboard/ResetAccountModal";
 import { Button } from "@/components/ui/button";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useTradingAccounts, useLiveAccount, tradingKeys } from "@/hooks/useTrading";
@@ -57,6 +62,7 @@ const DashboardHome = () => {
   const [dateRange, setDateRange] = useState("daily");
   const [chartType, setChartType] = useState<"equity" | "pnl">("equity");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const [resetOpen, setResetOpen] = useState(false);
 
   const view = useAccountView(selectedAccount || undefined);
   const liveQ = useLiveAccount(selectedAccount || undefined, {
@@ -132,7 +138,7 @@ const DashboardHome = () => {
               Overview of your funded trading performance
             </p>
           </div>
-          <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3">
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 w-full lg:w-auto">
             {hasAccounts && (
               <>
                 {/* Date Range Selector */}
@@ -158,6 +164,17 @@ const DashboardHome = () => {
                   onValueChange={setSelectedAccount}
                 />
                 <OpenPlatformButton credentials={accountData?.credentials} />
+                {accountData?.status === "Violated" && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setResetOpen(true)}
+                    className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70"
+                  >
+                    <RotateCcw size={14} className="mr-2" />
+                    Reset Account
+                  </Button>
+                )}
               </>
             )}
             {/* New Challenge button — always visible in top-right */}
@@ -269,6 +286,17 @@ const DashboardHome = () => {
               <AccountMetrics accountId={selectedAccount} />
             </div>
           </div>
+
+          {/* Full account-wide trade log (all trades, not just one calendar day) */}
+          <div className="mt-4 space-y-2">
+            <div className="flex items-center gap-2">
+              <BarChart3 size={14} className="text-muted-foreground" />
+              <span className="text-xs text-muted-foreground uppercase tracking-wider font-medium">
+                Trade Log
+              </span>
+            </div>
+            <AccountTradeLog accountId={selectedAccount} />
+          </div>
         </div>
       </ScrollReveal>
 
@@ -289,6 +317,20 @@ const DashboardHome = () => {
           <DailyAnalytics accountId={selectedAccount} selectedDate={selectedDate} />
         </div>
       </ScrollReveal>
+
+      <ResetAccountModal
+        account={
+          accountData
+            ? {
+                planType: accountData.plan,
+                accountSizeUsd: accountData.size,
+                isFunded: accountData.stage === "Funded",
+              }
+            : null
+        }
+        open={resetOpen}
+        onOpenChange={setResetOpen}
+      />
     </div>
   );
 };

--- a/src/pages/dashboard/DashboardJournal.tsx
+++ b/src/pages/dashboard/DashboardJournal.tsx
@@ -195,13 +195,13 @@ const DashboardJournal = () => {
       <div className="flex items-center justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-4">
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
             onClick={() => navigate(`/dashboard${accountQuery}`)}
-            className="gap-2"
+            className="gap-2 border-primary/30 text-primary hover:bg-primary/10 hover:text-primary"
           >
             <ArrowLeft size={16} />
-            Back to Dashboard
+            Back to Calendar
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
Batch of dashboard fixes from launch QA feedback (incl. account-reset placement + a profit-target-line bug found on a real account).

### Features / data
- **Account-wide Trade Log** (`AccountTradeLog`) on the dashboard — every trade on the selected account (net of commission), under the Instrument Breakdown section.
- **Wired the dead Instrument Breakdown tiles** — Instrument Breakdown, Trade Direction, Avg Duration were hardcoded-empty; now derived from real trades.
- **Account reset (#9) placement** — moved Reset to **inactive (violated) accounts** (not active — no reason to reset a live one; not permanently-closed), and **mirrored on the dashboard** when viewing a violated account. Shared `ResetAccountModal`. **Gated "Coming soon"**: a read-only prod probe found **0/27 programs have a reset URL** and the direct `checkout-reset` API resets without payment, so paid reset can't be wired yet — flip `RESET_ENABLED` + add the checkout link once YPF provides it.

### Bug fixes
- **Profit-target line missing on passed/closed eval accounts** — when an evaluation passes, its challenge advances to the FUNDED phase (0 profit target), so the adapter computed `profitTarget = 0` and hid the line (e.g. an Advanced 50K at $54,125 that cleared the $53,000 target). Fix: fall back to the ~6% eval target for **Standard/Advanced** plans; **Builder/Dynasty** stay 0 (instant-funded, genuinely no target). The line now renders (and flips to "reached").
- **Calendar daily P&L** `text-[8px]` → enlarged P&L + day number.
- **Day-of-Week heatmap** profit color gold→green to match the calendar; k-formatted amounts.
- **Journal back nav** → clearer "Back to Calendar" button.

### Mobile
- Account selector full-width on mobile (was fixed 300px overflow); header controls stretch; credentials login truncates; affiliate support email wraps; account tables scroll.

## Notes
- Profit-target line behavior otherwise left as-is (top badge when out of range) per earlier decision.
- Full pixel mobile QA still wants a device pass; this addresses the high-confidence overflow/spacing issues.

## Verify
Build clean (11 routes prerender), typecheck clean, lint at baseline (6 err/23 warn, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
