### PR TITLE
Lower countdown box below navbar with comfortable spacing

### DIFF
--- a/src/components/home/LaunchCountdown.tsx
+++ b/src/components/home/LaunchCountdown.tsx
@@ -37,7 +37,7 @@ const LaunchCountdown = () => {
   }, []);
 
   return (
-    <div className="flex justify-center px-4 mt-8 mb-6">
+    <div className="flex justify-center px-4 mt-16 sm:mt-20 mb-6">
       <div
         className="glass-card border border-gold/30 rounded-xl px-6 py-4 text-center"
         style={{


### PR DESCRIPTION
## Summary

- Increases the countdown box top margin from `mt-8` (32px) to `mt-16` on mobile and `mt-20` on sm+ screens (~64–80px), placing it clearly below the navbar with ~50–60px of visible breathing room
- No changes to countdown logic, styling, text, timer target, navbar, hero, or any other section

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvnQJnFgB2UUbHSLgHwHHB)_