### PR TITLE
Wire KYC status sync + in-app verification on profile

### DIFF
--- a/src/hooks/useKyc.ts
+++ b/src/hooks/useKyc.ts
@@ -1,0 +1,39 @@
+// =============================================================================
+// Dynasty Futures - KYC React Query Hooks
+// =============================================================================
+// Surfaces the trader's identity-verification status (synced from YPF) and the
+// action to initiate it. The verification itself completes in YPF's portal.
+// =============================================================================
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { kycService, type KycState } from '@/services/kyc';
+import type { ApiResponse, ApiError } from '@/types/api';
+
+export const kycKeys = {
+  all: ['kyc'] as const,
+  status: () => [...kycKeys.all, 'status'] as const,
+};
+
+/**
+ * Fetch + refresh the trader's KYC status from YPF. Enabled only when signed in.
+ */
+export const useKycStatus = (enabled = true) =>
+  useQuery<ApiResponse<KycState>, ApiError>({
+    queryKey: kycKeys.status(),
+    queryFn: () => kycService.status(),
+    enabled,
+    staleTime: 30_000,
+  });
+
+/**
+ * Initiate verification on YPF, then write the refreshed status into the cache.
+ */
+export const useRequestKyc = () => {
+  const qc = useQueryClient();
+  return useMutation<ApiResponse<KycState>, ApiError, void>({
+    mutationFn: () => kycService.request(),
+    onSuccess: (data) => {
+      qc.setQueryData(kycKeys.status(), data);
+    },
+  });
+};

--- a/src/pages/dashboard/DashboardProfile.tsx
+++ b/src/pages/dashboard/DashboardProfile.tsx
@@ -38,6 +38,7 @@ import { ApiError } from "@/types/api";
 import type { User as UserType } from "@/types/user";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useUserPlatformProfile } from "@/hooks/useUsers";
+import { useKycStatus, useRequestKyc } from "@/hooks/useKyc";
 
 // KYC is completed in the YPF-hosted trading portal (it owns identity
 // verification); we surface status here and hand off to complete/resubmit.
@@ -52,6 +53,13 @@ const DashboardProfile = () => {
   // of blank fields. Returns 400 (caught by the hook) until the user is linked.
   const platformProfileQ = useUserPlatformProfile(user?.id);
   const platformProfile = platformProfileQ.data?.data;
+
+  // KYC status is synced from YPF (identity verification is hosted there). This
+  // refreshes on mount so the badge is truthful rather than the stale local
+  // default; falls back to the auth user's value while loading.
+  const kycQuery = useKycStatus(!!user);
+  const requestKycMutation = useRequestKyc();
+  const kycStatus = kycQuery.data?.data?.status ?? user?.kycStatus ?? "NOT_STARTED";
 
   // Personal info form state
   const [profileForm, setProfileForm] = useState({
@@ -147,11 +155,27 @@ const DashboardProfile = () => {
     }
   }, [user, platformProfile]);
 
+  // Initiate verification on YPF (flips their requestKyc flag) then hand off to
+  // the YPF-hosted Sumsub flow. We don't host Sumsub — YPF owns it and reports
+  // the result back via the synced kycStatus above.
+  const handleStartKyc = () => {
+    requestKycMutation.mutate(undefined, {
+      onSuccess: () =>
+        window.open(KYC_PORTAL_URL, "_blank", "noopener,noreferrer"),
+      onError: (e) =>
+        toast({
+          title: "Couldn't start verification",
+          description: e.message,
+          variant: "destructive",
+        }),
+    });
+  };
+
   // KYC progress derived from user data
   const kycSteps = [
     { label: "Email Verified", done: user?.emailVerified ?? false },
     { label: "Phone Verified", done: false },
-    { label: "ID Verification", done: user?.kycStatus === "APPROVED" },
+    { label: "ID Verification", done: kycStatus === "APPROVED" },
   ];
   const kycCompleted = kycSteps.filter((s) => s.done).length;
   const kycProgress = Math.round((kycCompleted / kycSteps.length) * 100);
@@ -284,17 +308,17 @@ const DashboardProfile = () => {
                 <p className="text-muted-foreground text-sm mt-1">{user?.email}</p>
                 <span
                   className={`inline-flex items-center gap-1.5 mt-2 text-xs font-semibold px-2.5 py-1 rounded-full ${
-                    user?.kycStatus === "APPROVED"
+                    kycStatus === "APPROVED"
                       ? "bg-primary/20 text-primary"
                       : "bg-yellow-500/20 text-yellow-500"
                   }`}
                 >
-                  {user?.kycStatus === "APPROVED" ? (
+                  {kycStatus === "APPROVED" ? (
                     <CheckCircle size={11} />
                   ) : (
                     <AlertCircle size={11} />
                   )}
-                  {user?.kycStatus === "APPROVED" ? "Verified" : "Unverified"}
+                  {kycStatus === "APPROVED" ? "Verified" : "Unverified"}
                 </span>
               </div>
             </div>
@@ -731,7 +755,7 @@ const DashboardProfile = () => {
               </div>
 
               {(() => {
-                const status = user?.kycStatus ?? "NOT_STARTED";
+                const status = kycStatus;
                 const cfg = {
                   APPROVED: {
                     cls: "bg-primary/10 border-primary/20 text-primary",
@@ -801,21 +825,25 @@ const DashboardProfile = () => {
 
               <p className="text-xs text-muted-foreground mt-6">
                 KYC status:{" "}
-                <span className="font-medium text-foreground">
-                  {user?.kycStatus ?? "NOT_STARTED"}
-                </span>
+                <span className="font-medium text-foreground">{kycStatus}</span>
               </p>
 
-              {user?.kycStatus !== "APPROVED" && user?.kycStatus !== "PENDING" && (
+              {kycStatus !== "APPROVED" && kycStatus !== "PENDING" && (
                 <Button
-                  asChild
+                  onClick={handleStartKyc}
+                  disabled={requestKycMutation.isPending}
                   className="w-full mt-4 btn-gradient-animated text-primary-foreground py-6 text-base"
                 >
-                  <a href={KYC_PORTAL_URL} target="_blank" rel="noopener noreferrer">
-                    {user?.kycStatus === "REJECTED"
-                      ? "Resubmit Verification"
-                      : "Start Verification"}
-                  </a>
+                  {requestKycMutation.isPending ? (
+                    <>
+                      <Loader2 size={16} className="mr-2 animate-spin" />
+                      Starting…
+                    </>
+                  ) : kycStatus === "REJECTED" ? (
+                    "Resubmit Verification"
+                  ) : (
+                    "Start Verification"
+                  )}
                 </Button>
               )}
             </div>

--- a/src/services/kyc.ts
+++ b/src/services/kyc.ts
@@ -1,0 +1,28 @@
+// =============================================================================
+// Dynasty Futures - KYC Service
+// =============================================================================
+// Identity verification (Sumsub) is hosted by YPF. These endpoints sync the
+// trader's verification status from YPF and let them initiate the flow; the
+// actual document capture happens in YPF's portal (hand-off).
+// =============================================================================
+
+import { apiClient } from '@/services/api';
+import type { ApiResponse } from '@/types/api';
+
+export type KycStatus = 'NOT_STARTED' | 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface KycState {
+  status: KycStatus;
+  /** True once the user has a YPF account so verification can run. */
+  linked: boolean;
+}
+
+export const kycService = {
+  /** GET /v1/kyc — refresh status from YPF and return it. */
+  status: (): Promise<ApiResponse<KycState>> =>
+    apiClient.get<ApiResponse<KycState>>('/kyc'),
+
+  /** POST /v1/kyc/request — initiate verification on YPF, return refreshed status. */
+  request: (): Promise<ApiResponse<KycState>> =>
+    apiClient.post<ApiResponse<KycState>>('/kyc/request'),
+};


### PR DESCRIPTION
## Problem
The Verification/KYC tab read `user.kycStatus`, but the backend never wrote it — so it sat at `NOT_STARTED` forever and the badge always said "Unverified", even for verified traders. The "Start Verification" button was a plain link to the portal.

## What this does
Pairs with **DF-Backend #30** (which syncs YPF's status + adds `requestkyc`).

- New `kyc` service + `useKyc` hook — `useKycStatus` refreshes the real status from YPF on mount; `useRequestKyc` writes the result into the cache.
- `DashboardProfile`: the badge, status banner, verification steps, and status line all read the **synced** status (falls back to the auth user's value while loading).
- **Start Verification / Resubmit** now calls `POST /v1/kyc/request` (flips YPF's flag) then opens the YPF portal for the hosted **Sumsub** flow — instead of a bare link. Shows a pending spinner and toasts on failure (e.g. not yet linked to a YPF account).

We intentionally **don't host Sumsub** — YPF owns it (their Sumsub account / server-minted token), so the actual document capture stays in their portal and the result flows back via the synced status.

Build clean (11 routes prerender), lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
