### PR TITLE
Fix affiliate referral link URL (checkout host + refcode)

### DIFF
--- a/src/pages/dashboard/DashboardAffiliate.tsx
+++ b/src/pages/dashboard/DashboardAffiliate.tsx
@@ -33,11 +33,11 @@ import { useAffiliateStatus } from "@/hooks/useAffiliate";
 import AffiliateRegistrationModal from "@/components/dashboard/AffiliateRegistrationModal";
 
 // Base used to build an affiliate's referral link from their referral code.
-// Adjust if YPF/WooCommerce expects a different referral URL scheme.
-const REFERRAL_LINK_BASE = "https://www.dynastyfuturesdyn.com/";
+// Must match the CRM's referral URL scheme (checkout host + `refcode` param).
+const REFERRAL_LINK_BASE = "https://checkout.dynastyfuturesdyn.com/checkout";
 
 const buildReferralLink = (code: string): string =>
-  `${REFERRAL_LINK_BASE}?ref=${encodeURIComponent(code)}`;
+  `${REFERRAL_LINK_BASE}?refcode=${encodeURIComponent(code)}`;
 
 const formatCouponDiscount = (
   discountType: string | null,


### PR DESCRIPTION
## What
Corrects the affiliate referral link to match the CRM's actual scheme:

- **Now:** `https://checkout.dynastyfuturesdyn.com/checkout?refcode=<code>`
- **Was:** `https://www.dynastyfuturesdyn.com/?ref=<code>`

## Why a separate PR
This fix was amended onto #177 but the **pre-amend** commit is what got merged, so main shipped the re-apply fix without this one. Re-cut off fresh main.

## Verified
`npm run build` clean (11 routes). Lint at baseline.