### PR TITLE
Allow continuing KYC while verification is pending

### DIFF
--- a/src/pages/dashboard/DashboardProfile.tsx
+++ b/src/pages/dashboard/DashboardProfile.tsx
@@ -828,7 +828,7 @@ const DashboardProfile = () => {
                 <span className="font-medium text-foreground">{kycStatus}</span>
               </p>
 
-              {kycStatus !== "APPROVED" && kycStatus !== "PENDING" && (
+              {kycStatus !== "APPROVED" && (
                 <Button
                   onClick={handleStartKyc}
                   disabled={requestKycMutation.isPending}
@@ -837,10 +837,12 @@ const DashboardProfile = () => {
                   {requestKycMutation.isPending ? (
                     <>
                       <Loader2 size={16} className="mr-2 animate-spin" />
-                      Starting…
+                      {kycStatus === "PENDING" ? "Resuming…" : "Starting…"}
                     </>
                   ) : kycStatus === "REJECTED" ? (
                     "Resubmit Verification"
+                  ) : kycStatus === "PENDING" ? (
+                    "Continue Verification"
                   ) : (
                     "Start Verification"
                   )}


### PR DESCRIPTION
## What

While `kycStatus` is `PENDING`, the KYC tab now keeps the verification button visible and labels it **"Continue Verification"** (it was hidden entirely once a request went out).

## Why

A trader who kicked off verification on the YPF portal but didn't finish had no way back in from the DF dashboard — the only CTA disappeared the moment status flipped to `PENDING`. Now they can re-enter the flow without hunting for the portal link.

## Behavior

- Button shows for every non-`APPROVED` status (was: hidden when `APPROVED` **or** `PENDING`).
- Label by status: `REJECTED` → "Resubmit Verification", `PENDING` → "Continue Verification", else "Start Verification". Spinner reads "Resuming…" vs "Starting…" accordingly.
- Click path unchanged — `handleStartKyc` re-flips the YPF `requestKyc` flag and opens the portal; synced `kycStatus` reflects the result.

Build clean (11 routes prerender).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
