### PR TITLE
Gate affiliate apply behind login + fix KYC verification hand-off

### DIFF
--- a/src/pages/Affiliates.tsx
+++ b/src/pages/Affiliates.tsx
@@ -4,7 +4,9 @@ import PageMeta from "@/components/seo/PageMeta";
 import JsonLd, { breadcrumb, faqPageSchema } from "@/components/seo/JsonLd";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { Button } from "@/components/ui/button";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { useAuth } from "@/hooks/useAuth";
 import {
   Accordion,
   AccordionContent,
@@ -204,6 +206,20 @@ const affiliateFaqs = [
 
 const Affiliates = () => {
   const [isAffiliateModalOpen, setIsAffiliateModalOpen] = useState(false);
+  const { isAuthenticated, isLoading } = useAuth();
+  const navigate = useNavigate();
+
+  // Anyone can read the page, but submitting an application requires an account.
+  // Logged out → send to login and return here afterwards (no wasted form fill).
+  const handleApplyClick = () => {
+    if (isLoading) return;
+    if (!isAuthenticated) {
+      toast.info("Please log in or create an account to apply as an affiliate.");
+      navigate("/login", { state: { from: "/affiliates" } });
+      return;
+    }
+    setIsAffiliateModalOpen(true);
+  };
 
   return (
     <Layout>
@@ -275,7 +291,7 @@ const Affiliates = () => {
                   variant="outline"
                   size="lg"
                   className="border-border/50 hover:border-primary/50 hover:text-primary"
-                  onClick={() => setIsAffiliateModalOpen(true)}
+                  onClick={handleApplyClick}
                 >
                   Apply to Become an Affiliate
                 </Button>
@@ -723,7 +739,7 @@ const Affiliates = () => {
                   variant="outline"
                   size="lg"
                   className="border-border/50 hover:border-primary/50 hover:text-primary"
-                  onClick={() => setIsAffiliateModalOpen(true)}
+                  onClick={handleApplyClick}
                 >
                   Apply to Become an Affiliate
                 </Button>

--- a/src/pages/dashboard/DashboardProfile.tsx
+++ b/src/pages/dashboard/DashboardProfile.tsx
@@ -42,7 +42,9 @@ import { useKycStatus, useRequestKyc } from "@/hooks/useKyc";
 
 // KYC is completed in the YPF-hosted trading portal (it owns identity
 // verification); we surface status here and hand off to complete/resubmit.
-const KYC_PORTAL_URL = "https://admin.dynastyfuturesdyn.com";
+// Deep-link straight to the verification page (the bare dashboard root drops
+// the trader on their dashboard, not the Sumsub verification flow).
+const KYC_PORTAL_URL = "https://admin.dynastyfuturesdyn.com/verifications";
 
 const DashboardProfile = () => {
   const { user, refreshUser } = useAuth();
@@ -155,13 +157,23 @@ const DashboardProfile = () => {
     }
   }, [user, platformProfile]);
 
+  const openVerificationPortal = () =>
+    window.open(KYC_PORTAL_URL, "_blank", "noopener,noreferrer");
+
   // Initiate verification on YPF (flips their requestKyc flag) then hand off to
   // the YPF-hosted Sumsub flow. We don't host Sumsub — YPF owns it and reports
   // the result back via the synced kycStatus above.
+  //
+  // Only NOT_STARTED needs the request call. Once it's PENDING/REJECTED the
+  // verification already exists on YPF's side — re-requesting 400s ("KYC already
+  // requested"), so "Continue/Resubmit" just deep-links to the verification page.
   const handleStartKyc = () => {
+    if (kycStatus === "PENDING" || kycStatus === "REJECTED") {
+      openVerificationPortal();
+      return;
+    }
     requestKycMutation.mutate(undefined, {
-      onSuccess: () =>
-        window.open(KYC_PORTAL_URL, "_blank", "noopener,noreferrer"),
+      onSuccess: openVerificationPortal,
       onError: (e) =>
         toast({
           title: "Couldn't start verification",


### PR DESCRIPTION
## Affiliate — require login to apply

The "Apply to Become an Affiliate" buttons (hero + final CTA) opened the application form for anyone. Now:
- Logged out → toast + redirect to `/login` with `state:{from:'/affiliates'}` (returns to the page after auth — no wasted 3-step form fill).
- Logged in → opens the registration modal as before.

The page content stays **fully public to read**; only *submitting* requires an account. Re-enforced server-side by the paired backend PR (`/v1/affiliates/apply` now `authenticate`).

## KYC — fix the verification hand-off

Two issues:
1. "Start Verification" opened the admin dashboard **root**, dropping the trader on their dashboard instead of the verification flow.
2. After starting, status goes `PENDING`; clicking "Continue Verification" re-called `requestKyc`, and YPF **400s "KYC already requested"**.

Fixes (`DashboardProfile.tsx`):
- Deep-link the hand-off to `https://admin.dynastyfuturesdyn.com/verifications`.
- `PENDING` / `REJECTED` no longer re-call `requestKyc` — "Continue / Resubmit Verification" opens the verification page directly. Only `NOT_STARTED` calls the request endpoint (to flip YPF's flag) before handing off.

## Verification

- `npm run build` clean (11 routes prerendered)
- lint clean on both edited files
