### PR TITLE
Add passed-eval CTA: "Upgrade to Funded" / Standard activation

### DIFF
--- a/src/components/dashboard/UpgradeAccountModal.tsx
+++ b/src/components/dashboard/UpgradeAccountModal.tsx
@@ -1,0 +1,133 @@
+import { ArrowUpCircle, Loader2, TrendingUp } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useUpgradeAccount } from "@/hooks/useTrading";
+import type { ApiError } from "@/types/api";
+
+// =============================================================================
+// Upgrade Account modal (dashboard)
+// =============================================================================
+// Promotes an evaluation account that has met its profit target to a funded
+// account. Mirrors YPF's own "Upgrade Account" button — it calls our backend,
+// which hits YPF's `/upgrade` endpoint (the one gated on `isLevelUpReached`).
+// Unlike the reset flow this is live: YPF is the final authority and may still
+// reject, in which case we surface the error.
+// =============================================================================
+
+export interface UpgradeAccountTarget {
+  accountId: string;
+  accountName: string;
+  currentProgram?: string;
+  nextProgram?: string;
+}
+
+interface UpgradeAccountModalProps {
+  account: UpgradeAccountTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const UpgradeAccountModal = ({
+  account,
+  open,
+  onOpenChange,
+}: UpgradeAccountModalProps) => {
+  const upgrade = useUpgradeAccount({
+    onSuccess: () => {
+      toast.success("Upgrade requested", {
+        description:
+          "Your upgrade is pending approval. Once approved, your account becomes funded and the dashboard updates automatically.",
+      });
+      onOpenChange(false);
+    },
+    onError: (err: ApiError) => {
+      toast.error("Couldn't upgrade account", {
+        description:
+          err.message ?? "Please try again, or contact support if this persists.",
+      });
+    },
+  });
+
+  const handleConfirm = () => {
+    if (!account) return;
+    upgrade.mutate(account.accountId);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={upgrade.isPending ? undefined : onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowUpCircle size={18} className="text-primary" />
+            Upgrade to Funded
+          </DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-4 pt-1">
+              <p className="text-sm text-muted-foreground">
+                You've hit your profit target — congratulations. Requesting an
+                upgrade submits this account for review; once approved it moves
+                to its funded phase, where your profits become eligible for
+                payouts.
+              </p>
+
+              {account && (
+                <div className="rounded-xl border border-border/30 bg-muted/20 p-4 space-y-2 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Account</span>
+                    <span className="text-foreground font-medium">
+                      {account.accountName}
+                    </span>
+                  </div>
+                  {(account.currentProgram || account.nextProgram) && (
+                    <div className="flex items-center justify-between border-t border-border/20 pt-2 mt-2">
+                      <span className="text-muted-foreground">
+                        {account.currentProgram ?? "Evaluation"}
+                      </span>
+                      <span className="flex items-center gap-1.5 text-foreground font-medium">
+                        <TrendingUp size={14} className="text-primary" />
+                        {account.nextProgram ?? "Funded"}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <p className="text-xs text-muted-foreground">
+                This action is final and is handled by the trading platform.
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={upgrade.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={!account || upgrade.isPending}>
+            {upgrade.isPending ? (
+              <>
+                <Loader2 size={16} className="mr-2 animate-spin" />
+                Upgrading…
+              </>
+            ) : (
+              "Confirm Upgrade"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default UpgradeAccountModal;

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -74,6 +74,11 @@ export interface AccountData {
   profitSplit?: number;
   profitTradingDays?: number;
   credentials?: { login: string; password: string };
+  // True when the account hit its profit target and YPF will allow an
+  // eval → funded upgrade (drives the "Upgrade to Funded" CTA).
+  canUpgrade?: boolean;
+  // True once an upgrade has been requested and is awaiting CRM approval.
+  upgradePending?: boolean;
 }
 
 // Generate random but realistic equity curves

--- a/src/hooks/useTrading.ts
+++ b/src/hooks/useTrading.ts
@@ -213,3 +213,24 @@ export const useResetAccount = (
     },
   });
 };
+
+/**
+ * Upgrade an evaluation account that has hit its profit target to a funded
+ * account (mirrors YPF's "Upgrade Account" button). Invalidates the account
+ * detail + lists so the dashboard reflects the new FUNDED phase.
+ */
+export const useUpgradeAccount = (
+  options?: UseMutationOptions<ApiResponse<LiveSnapshot>, ApiError, string>,
+) => {
+  const qc = useQueryClient();
+  return useMutation<ApiResponse<LiveSnapshot>, ApiError, string>({
+    mutationFn: (id: string) => tradingService.upgradeAccount(id),
+    ...options,
+    onSuccess: (data, id, ctx) => {
+      qc.invalidateQueries({ queryKey: tradingKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: tradingKeys.live(id) });
+      qc.invalidateQueries({ queryKey: tradingKeys.accounts() });
+      options?.onSuccess?.(data, id, ctx);
+    },
+  });
+};

--- a/src/lib/activation.ts
+++ b/src/lib/activation.ts
@@ -1,0 +1,38 @@
+// =============================================================================
+// Standard-account activation
+// =============================================================================
+// Standard plans owe an $80 activation fee to convert a passed evaluation into
+// a funded account — Advanced/Builder (Dynasty) do not. The fee is paid on the
+// YPF-owned WooCommerce store via a per-size activation product. We deep-link
+// the size-matched product; binding to the trader happens by email at checkout.
+//
+// NOTE: an account-SPECIFIC binding (when a trader has several same-size
+// Standard accounts pending activation) needs YPF's server-minted `ypf-ref`
+// token, which we can't forge — these permalinks rely on email + size match.
+// =============================================================================
+
+export const STANDARD_ACTIVATION_FEE_USD = 80;
+
+const ACTIVATION_PRODUCT_BASE = "https://checkout.dynastyfuturesdyn.com/product";
+
+const sizeSlug = (sizeUsd: number): string | null => {
+  if (sizeUsd <= 25000) return "25k";
+  if (sizeUsd <= 50000) return "50k";
+  if (sizeUsd <= 100000) return "100k";
+  if (sizeUsd <= 150000) return "150k";
+  return null;
+};
+
+/**
+ * The activation-checkout URL for a Standard account of the given size, or
+ * null when the plan carries no activation fee (Advanced/Builder) or the size
+ * is unrecognized.
+ */
+export const standardActivationUrl = (
+  plan: string,
+  sizeUsd: number,
+): string | null => {
+  if (plan !== "Standard") return null;
+  const slug = sizeSlug(sizeUsd);
+  return slug ? `${ACTIVATION_PRODUCT_BASE}/${slug}-standard-activation/` : null;
+};

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -422,6 +422,16 @@ export const adaptAccountView = (
       ? { profitTradingDays: live.profitTradingDays }
       : {}),
     ...(live?.loginCredentials ? { credentials: live.loginCredentials } : {}),
+    // Eligible for an eval → funded upgrade when YPF reports the level-up has
+    // been reached AND the account is still Active (once requested it moves to
+    // "UpgradePending" — a second request 400s). Backend re-validates.
+    ...(live?.isLevelUpReached &&
+    !live.upgradeRequestDate &&
+    live.status === "Active"
+      ? { canUpgrade: true }
+      : {}),
+    // An upgrade was requested and is awaiting approval in the YPF CRM.
+    ...(live?.status === "UpgradePending" ? { upgradePending: true } : {}),
   };
 };
 

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -12,6 +12,7 @@ import {
   AlertCircle,
   Plus,
   RotateCcw,
+  ArrowUpCircle,
 } from "lucide-react";
 import { format, isToday } from "date-fns";
 import { toast } from "sonner";
@@ -28,6 +29,11 @@ import DailyAnalytics from "@/components/dashboard/DailyAnalytics";
 import ResetAccountModal, {
   type ResetAccountTarget,
 } from "@/components/dashboard/ResetAccountModal";
+import UpgradeAccountModal from "@/components/dashboard/UpgradeAccountModal";
+import {
+  standardActivationUrl,
+  STANDARD_ACTIVATION_FEE_USD,
+} from "@/lib/activation";
 import { Button } from "@/components/ui/button";
 import ScrollReveal from "@/components/ui/ScrollReveal";
 import { useTradingAccounts, useLiveAccount, tradingKeys } from "@/hooks/useTrading";
@@ -63,6 +69,7 @@ const DashboardHome = () => {
   const [chartType, setChartType] = useState<"equity" | "pnl">("equity");
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
   const [resetOpen, setResetOpen] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
 
   const view = useAccountView(selectedAccount || undefined);
   const liveQ = useLiveAccount(selectedAccount || undefined, {
@@ -81,6 +88,12 @@ const DashboardHome = () => {
   }, [view.data, liveQ.data]);
 
   const isBuilderAccount = accountData?.planType === "Builder";
+
+  // Standard plans go funded via a paid activation checkout; others upgrade
+  // directly. Null for non-Standard (or unknown size) → the direct-upgrade CTA.
+  const activationUrl = accountData
+    ? standardActivationUrl(accountData.plan, accountData.size)
+    : null;
 
   const chartData = useMemo(() => {
     if (!accountData) return [];
@@ -164,6 +177,35 @@ const DashboardHome = () => {
                   onValueChange={setSelectedAccount}
                 />
                 <OpenPlatformButton credentials={accountData?.credentials} />
+                {accountData?.canUpgrade &&
+                  (activationUrl ? (
+                    // Standard plans pay an $80 activation fee on the YPF store.
+                    <Button
+                      size="sm"
+                      onClick={() =>
+                        window.open(activationUrl, "_blank", "noopener,noreferrer")
+                      }
+                      className="btn-gradient-animated text-primary-foreground"
+                    >
+                      <ArrowUpCircle size={14} className="mr-2" />
+                      Activate Account – ${STANDARD_ACTIVATION_FEE_USD}
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => setUpgradeOpen(true)}
+                      className="btn-gradient-animated text-primary-foreground"
+                    >
+                      <ArrowUpCircle size={14} className="mr-2" />
+                      Upgrade to Funded
+                    </Button>
+                  ))}
+                {accountData?.upgradePending && (
+                  <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-3 py-1.5 text-sm font-medium text-primary">
+                    <ArrowUpCircle size={14} />
+                    Upgrade Pending Approval
+                  </span>
+                )}
                 {accountData?.status === "Violated" && (
                   <Button
                     variant="outline"
@@ -328,6 +370,23 @@ const DashboardHome = () => {
         }
         open={resetOpen}
         onOpenChange={setResetOpen}
+      />
+
+      <UpgradeAccountModal
+        account={
+          accountData && selectedAccount
+            ? {
+                accountId: selectedAccount,
+                accountName: accountData.name,
+                currentProgram: accountData.plan
+                  ? `${accountData.plan} Evaluation`
+                  : undefined,
+                nextProgram: accountData.nextProgramName,
+              }
+            : null
+        }
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
       />
     </div>
   );

--- a/src/services/trading.ts
+++ b/src/services/trading.ts
@@ -82,6 +82,14 @@ export const tradingService = {
     apiClient.post<ApiResponse<LiveSnapshot>>(`/trading/accounts/${id}/reset`),
 
   /**
+   * Upgrade an evaluation account that hit its profit target to a funded
+   * account. Mirrors YPF's own "Upgrade Account" button.
+   * POST /v1/trading/accounts/:id/upgrade
+   */
+  upgradeAccount: (id: string): Promise<ApiResponse<LiveSnapshot>> =>
+    apiClient.post<ApiResponse<LiveSnapshot>>(`/trading/accounts/${id}/upgrade`),
+
+  /**
    * One-time SSO URL into the trading platform's web dashboard.
    * GET /v1/trading/dashboard-url
    *

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -76,6 +76,10 @@ export interface LiveSnapshot {
   activeDays?: number;
   // Trader's profit-split % on this account
   profitSplit?: number;
+  // Eval → funded upgrade eligibility (YPF's own "level up reached" flag)
+  isLevelUpReached?: boolean;
+  // ISO timestamp once an upgrade has been requested (absent = none pending)
+  upgradeRequestDate?: string;
   // Drawdown metrics
   drawDown?: number;
   maxDrawDown?: number;


### PR DESCRIPTION
Traders whose evaluation account hits its profit target now get a plan-aware call-to-action on the dashboard, mirroring YPF's provided dashboard.

- Advanced/Builder (no activation fee): "Upgrade to Funded" → confirmation modal → backend POST /upgrade → the account is submitted for upgrade and becomes funded once approved in the YPF CRM.
- Standard ($80 activation fee): "Activate Account – $80" → deep-links the size-matched WooCommerce activation product (email-bound at checkout); Standard never hits the free /upgrade path.

- Surface YPF's `isLevelUpReached` / `upgradeRequestDate` / `status` on LiveSnapshot; derive `canUpgrade` (level-up reached AND state still Active) and `upgradePending` (state UpgradePending) in the trading adapter.
- The CTA hides once an upgrade is requested; an "Upgrade Pending Approval" badge shows while it awaits CRM approval.
- `tradingService.upgradeAccount` + `useUpgradeAccount` mutation (invalidates account detail/live/lists).
- New UpgradeAccountModal; new lib/activation.ts (size → activation product).

Pairs with DF-Backend #36 + #37. Build clean (11 routes prerender), lint baseline.