### PR TITLE
Show UPGRADED accounts as "Upgraded" + group account lists

### DIFF
--- a/src/components/dashboard/AccountSelector.tsx
+++ b/src/components/dashboard/AccountSelector.tsx
@@ -1,7 +1,9 @@
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
@@ -13,18 +15,85 @@ interface AccountSelectorProps {
   onValueChange?: (value: string) => void;
 }
 
-const stageLabel = (status: TradingAccount['status']): string =>
-  status === 'PASSED' || status === 'FUNDED' ? 'Funded' : 'Evaluation';
+type StatusLabel = 'Active' | 'Violated' | 'Closed' | 'Upgraded';
 
-const statusLabel = (status: TradingAccount['status']): 'Active' | 'Violated' | 'Closed' => {
+const stageLabel = (status: TradingAccount['status']): string =>
+  status === 'PASSED' || status === 'FUNDED' || status === 'UPGRADED'
+    ? 'Funded'
+    : 'Evaluation';
+
+const statusLabel = (status: TradingAccount['status']): StatusLabel => {
+  if (status === 'UPGRADED') return 'Upgraded';
   if (status === 'CLOSED') return 'Closed';
   if (status === 'FAILED' || status === 'SUSPENDED') return 'Violated';
   return 'Active';
 };
 
+const badgeClass = (status: StatusLabel): string => {
+  switch (status) {
+    case 'Active':
+      return 'bg-primary/20 text-primary';
+    case 'Violated':
+      return 'bg-destructive/20 text-destructive';
+    case 'Upgraded':
+      return 'bg-gold-dark/20 text-gold-dark';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+};
+
+// Group accounts of the same plan/size together: rank by plan family, then by
+// account size ascending, so the dropdown reads in a predictable order rather
+// than the arbitrary order the API returns.
+const planRank = (name: string): number => {
+  const n = name.toLowerCase();
+  if (n.includes('standard')) return 0;
+  if (n.includes('advanced')) return 1;
+  return 2; // Builder / Dynasty
+};
+
+const sortByTypeAndSize = (a: TradingAccount, b: TradingAccount): number => {
+  const an = a.accountType.displayName || a.accountType.name;
+  const bn = b.accountType.displayName || b.accountType.name;
+  const rank = planRank(an) - planRank(bn);
+  if (rank !== 0) return rank;
+  const sizeDiff = Number(a.accountType.accountSize) - Number(b.accountType.accountSize);
+  if (sizeDiff !== 0) return sizeDiff;
+  return an.localeCompare(bn);
+};
+
 const AccountSelector = ({ value, onValueChange }: AccountSelectorProps) => {
   const { data, isLoading } = useTradingAccounts();
   const accounts = data?.data ?? [];
+
+  // Active accounts first, inactive (violated / closed / upgraded) after — each
+  // sorted by plan family + size.
+  const isActive = (a: TradingAccount) => statusLabel(a.status) === 'Active';
+  const activeAccounts = accounts.filter(isActive).sort(sortByTypeAndSize);
+  const inactiveAccounts = accounts.filter((a) => !isActive(a)).sort(sortByTypeAndSize);
+
+  const renderItem = (account: TradingAccount) => {
+    const stage = stageLabel(account.status);
+    const status = statusLabel(account.status);
+    const name = account.accountType.displayName || account.accountType.name;
+    return (
+      <SelectItem
+        key={account.id}
+        value={account.id}
+        className="focus:bg-primary/10 focus:text-foreground rounded-lg my-0.5"
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-medium">{name}</span>
+          <span className="text-xs text-muted-foreground">• {stage}</span>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full font-medium ${badgeClass(status)}`}
+          >
+            {status}
+          </span>
+        </div>
+      </SelectItem>
+    );
+  };
 
   return (
     <Select value={value} onValueChange={onValueChange}>
@@ -39,35 +108,24 @@ const AccountSelector = ({ value, onValueChange }: AccountSelectorProps) => {
             No accounts yet
           </div>
         )}
-        {accounts.map((account) => {
-          const stage = stageLabel(account.status);
-          const status = statusLabel(account.status);
-          const name =
-            account.accountType.displayName || account.accountType.name;
-          return (
-            <SelectItem
-              key={account.id}
-              value={account.id}
-              className="focus:bg-primary/10 focus:text-foreground rounded-lg my-0.5"
-            >
-              <div className="flex items-center gap-3">
-                <span className="font-medium">{name}</span>
-                <span className="text-xs text-muted-foreground">• {stage}</span>
-                <span
-                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                    status === 'Active'
-                      ? 'bg-primary/20 text-primary'
-                      : status === 'Violated'
-                      ? 'bg-destructive/20 text-destructive'
-                      : 'bg-muted text-muted-foreground'
-                  }`}
-                >
-                  {status}
-                </span>
-              </div>
-            </SelectItem>
-          );
-        })}
+
+        {activeAccounts.length > 0 && (
+          <SelectGroup>
+            <SelectLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+              Active Accounts
+            </SelectLabel>
+            {activeAccounts.map(renderItem)}
+          </SelectGroup>
+        )}
+
+        {inactiveAccounts.length > 0 && (
+          <SelectGroup>
+            <SelectLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+              Inactive Accounts
+            </SelectLabel>
+            {inactiveAccounts.map(renderItem)}
+          </SelectGroup>
+        )}
       </SelectContent>
     </Select>
   );

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -40,7 +40,7 @@ export interface AccountData {
   plan: 'Standard' | 'Advanced' | 'Builder';
   planType: 'Standard' | 'Advanced' | 'Builder';
   stage: 'Evaluation' | 'Funded';
-  status: 'Active' | 'Violated' | 'Closed';
+  status: 'Active' | 'Violated' | 'Closed' | 'Upgraded';
   startingBalance: number;
   profitTarget: number;
   maxDrawdown: number;

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -52,9 +52,12 @@ const detectPlan = (a: TradingAccount): AccountData['plan'] => {
 };
 
 const stageFor = (status: TradingAccount['status']): AccountData['stage'] =>
-  status === 'PASSED' || status === 'FUNDED' ? 'Funded' : 'Evaluation';
+  status === 'PASSED' || status === 'FUNDED' || status === 'UPGRADED'
+    ? 'Funded'
+    : 'Evaluation';
 
 const uiStatusFor = (status: TradingAccount['status']): AccountData['status'] => {
+  if (status === 'UPGRADED') return 'Upgraded';
   if (status === 'CLOSED') return 'Closed';
   if (status === 'FAILED' || status === 'SUSPENDED') return 'Violated';
   return 'Active';

--- a/src/pages/dashboard/DashboardAccounts.tsx
+++ b/src/pages/dashboard/DashboardAccounts.tsx
@@ -18,7 +18,7 @@ import ResetAccountModal, {
 import type { TradingAccount, AccountStatus } from "@/types/trading";
 
 type StageLabel = "Evaluation" | "Funded" | "Closed";
-type StatusLabel = "Active" | "Violated" | "Closed";
+type StatusLabel = "Active" | "Violated" | "Closed" | "Upgraded";
 
 interface AccountView {
   id: string;
@@ -54,6 +54,7 @@ const STAGE_BY_STATUS: Record<AccountStatus, StageLabel> = {
   SUSPENDED: "Funded",
   FAILED: "Closed",
   CLOSED: "Closed",
+  UPGRADED: "Funded",
 };
 
 const STATUS_LABEL_BY_STATUS: Record<AccountStatus, StatusLabel> = {
@@ -64,6 +65,7 @@ const STATUS_LABEL_BY_STATUS: Record<AccountStatus, StatusLabel> = {
   SUSPENDED: "Violated",
   FAILED: "Violated",
   CLOSED: "Closed",
+  UPGRADED: "Upgraded",
 };
 
 const toView = (a: TradingAccount): AccountView => ({
@@ -87,6 +89,7 @@ const getStatusBadge = (status: StatusLabel): string => {
     Active: "bg-primary/20 text-primary border-primary/30",
     Violated: "bg-destructive/20 text-destructive border-destructive/30",
     Closed: "bg-muted text-muted-foreground border-border",
+    Upgraded: "bg-gold-dark/20 text-gold-dark border-gold-dark/30",
   };
   return styles[status];
 };
@@ -98,6 +101,23 @@ const getStageBadge = (stage: StageLabel): string => {
     Closed: "bg-muted text-muted-foreground border-border",
   };
   return styles[stage];
+};
+
+// Group accounts of the same plan family + size together so each section reads
+// in a predictable order rather than the arbitrary order the API returns.
+const planRank = (name: string): number => {
+  const n = name.toLowerCase();
+  if (n.includes("standard")) return 0;
+  if (n.includes("advanced")) return 1;
+  return 2; // Builder / Dynasty
+};
+
+const byTypeAndSize = (a: AccountView, b: AccountView): number => {
+  const rank = planRank(a.planType) - planRank(b.planType);
+  if (rank !== 0) return rank;
+  const sizeDiff = a.accountSizeUsd - b.accountSizeUsd;
+  if (sizeDiff !== 0) return sizeDiff;
+  return a.planType.localeCompare(b.planType);
 };
 
 const truncateId = (id: string) => (id.length > 12 ? `${id.slice(0, 8)}…` : id);
@@ -277,12 +297,12 @@ const DashboardAccounts = () => {
   );
 
   const activeAccounts = useMemo(
-    () => accounts.filter((a) => a.status === "Active"),
+    () => accounts.filter((a) => a.status === "Active").sort(byTypeAndSize),
     [accounts],
   );
 
   const inactiveAccounts = useMemo(
-    () => accounts.filter((a) => a.status !== "Active"),
+    () => accounts.filter((a) => a.status !== "Active").sort(byTypeAndSize),
     [accounts],
   );
 

--- a/src/pages/dashboard/DashboardBilling.tsx
+++ b/src/pages/dashboard/DashboardBilling.tsx
@@ -81,6 +81,10 @@ const STATUS_CONFIG: Record<
     className:
       "text-muted-foreground bg-muted/30 border border-border/30",
   },
+  UPGRADED: {
+    label: "Upgraded",
+    className: "text-gold-dark bg-gold-dark/10 border border-gold-dark/20",
+  },
 };
 
 const StatusBadge = ({ status }: { status: AccountStatus }) => {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -16,7 +16,8 @@ export type AccountStatus =
   | 'FUNDED'
   | 'SUSPENDED'
   | 'FAILED'
-  | 'CLOSED';
+  | 'CLOSED'
+  | 'UPGRADED';
 
 export type ChallengePhase = 'PHASE_1' | 'PHASE_2' | 'FUNDED';
 


### PR DESCRIPTION
## UPGRADED status

Adds the `UPGRADED` account status end-to-end so a passed account that YPF retired (it spawns a new funded account and flips the original to `Upgraded`) renders correctly instead of being mislabelled funded/closed/violated:

- `types/account.ts`, `mockDashboardData` union, `tradingAdapter` (`uiStatusFor` → "Upgraded", `stageFor` → "Funded")
- `DashboardAccounts` maps + gold **"Upgraded"** badge — shows under **Inactive Accounts**, not resettable
- `DashboardBilling` status badge

## Account grouping

The account **dropdown** and the **Accounts page** now group **Active accounts first, then Inactive**, each sorted by plan family (Standard → Advanced → Builder) then size — instead of the arbitrary order the API returns.

## Verification

- `npm run build` clean (11 routes prerendered)
- lint clean on all touched files; `tsc` clean for these changes (pre-existing baseline errors elsewhere untouched)

Pairs with the backend PR that introduces the `UPGRADED` status (deploy + `prisma migrate deploy` first; the frontend safely handles the status whether or not it's present yet).
