### PR TITLE
Redirect traders to YPF-hosted dashboard while ours is unfinished

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,13 @@ VITE_GOOGLE_CLIENT_ID=
 # Crisp live-chat Website ID (UUID from Crisp → Settings → Website Settings → Setup)
 # Leave empty to disable the chat widget. Safe to commit — it's public by design.
 VITE_CRISP_WEBSITE_ID=
+
+# TEMPORARY: redirect traders to the YPF-hosted dashboard while our in-app
+# reset/activation checkout flows are unfinished. Set to "true" to enable the
+# redirect; leave empty/"false" to keep everyone on our in-app dashboard.
+VITE_EXTERNAL_DASHBOARD=
+
+# Comma-separated emails that stay on our in-app dashboard even when the redirect
+# above is enabled (staff / test accounts). Case-insensitive.
+# e.g. VITE_DASHBOARD_ALLOWLIST=ops@dynastyfuturesdyn.com,tester@example.com
+VITE_DASHBOARD_ALLOWLIST=

--- a/.env.production
+++ b/.env.production
@@ -17,3 +17,14 @@ VITE_USE_MOCK_DATA=false
 
 # Disable debug logging in production
 VITE_DEBUG_MODE=false
+
+# TEMPORARY: redirect traders to the YPF-hosted dashboard while our in-app
+# reset/activation checkout flows are unfinished. Turn OFF by setting this to
+# "false" in the Vercel dashboard (overrides this file) or git-reverting the
+# externalDashboardRedirect change.
+VITE_EXTERNAL_DASHBOARD=true
+
+# Comma-separated emails that stay on our in-app dashboard while the redirect
+# above is on (staff / test accounts). Managed in the Vercel dashboard, not
+# committed here — set VITE_DASHBOARD_ALLOWLIST there, then redeploy.
+VITE_DASHBOARD_ALLOWLIST=

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { env } from "@/config/env";
 import { AuthProvider } from "@/contexts/AuthContext";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import ExternalDashboardGate from "@/components/auth/ExternalDashboardGate";
 import { getPerfFlags } from "@/lib/perfFlags";
 import CookieConsentBanner from "@/components/ui/CookieConsentBanner";
 import CrispChat from "@/components/integrations/CrispChat";
@@ -95,9 +96,11 @@ export const AppRoutes = () => (
     {/* Dashboard Routes — requires authentication */}
     <Route path="/dashboard" element={
       <ProtectedRoute>
-        <LazyRoute>
-          <DashboardLayout />
-        </LazyRoute>
+        <ExternalDashboardGate>
+          <LazyRoute>
+            <DashboardLayout />
+          </LazyRoute>
+        </ExternalDashboardGate>
       </ProtectedRoute>
     }>
       <Route index element={<LazyRoute><DashboardHome /></LazyRoute>} />

--- a/src/components/auth/ExternalDashboardGate.tsx
+++ b/src/components/auth/ExternalDashboardGate.tsx
@@ -1,0 +1,51 @@
+// =============================================================================
+// ExternalDashboardGate (temporary)
+// =============================================================================
+// Bounces traders to the YPF-hosted dashboard while our in-app reset/activation
+// checkout flows are still being finished. Sits inside ProtectedRoute, so by the
+// time it renders the user is authenticated and we have their email.
+//
+// Catches ALL ways into /dashboard (navbar, post-login redirect, direct URL /
+// bookmark). Allowlisted emails — and everyone when VITE_EXTERNAL_DASHBOARD is
+// off — pass straight through unchanged.
+//
+// To revert: flip VITE_EXTERNAL_DASHBOARD to "false" (this no-ops) or git-revert
+// the commit. See src/lib/externalDashboard.ts.
+// =============================================================================
+
+import { type ReactNode, useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  EXTERNAL_DASHBOARD_URL,
+  shouldUseExternalDashboard,
+} from '@/lib/externalDashboard';
+
+interface ExternalDashboardGateProps {
+  children: ReactNode;
+}
+
+const ExternalDashboardGate = ({ children }: ExternalDashboardGateProps) => {
+  const { user, isLoading } = useAuth();
+  const redirect = !isLoading && shouldUseExternalDashboard(user?.email);
+
+  useEffect(() => {
+    if (redirect) {
+      window.location.replace(EXTERNAL_DASHBOARD_URL);
+    }
+  }, [redirect]);
+
+  // Hold a spinner while auth resolves or while the external redirect is firing,
+  // so our (unfinished) dashboard never flashes for a redirected trader.
+  if (isLoading || redirect) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default ExternalDashboardGate;

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ import {
   Users,
   ChevronDown,
   LifeBuoy,
+  type LucideIcon,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -29,7 +30,20 @@ import {
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
+import {
+  EXTERNAL_DASHBOARD_URL,
+  shouldUseExternalDashboard,
+} from "@/lib/externalDashboard";
 import logo from "@/assets/Dynasty_Futures.png";
+
+// When external = true the link points off-site (full-page nav) rather than to
+// an in-app route, so it renders as an <a href> instead of a react-router <Link>.
+type NavLink = {
+  name: string;
+  path: string;
+  icon: LucideIcon;
+  external?: boolean;
+};
 
 const helpCenterLinks = [
   { name: "Support", to: "/support" },
@@ -55,10 +69,24 @@ const Navbar = () => {
     navigate("/");
   };
 
+  // While our reset/activation flows are unfinished, non-allowlisted traders
+  // are redirected to the YPF-hosted dashboard, so the Dashboard link points
+  // off-site for them. See src/lib/externalDashboard.ts.
+  const redirectDashboard = shouldUseExternalDashboard(user?.email);
+
   // Build navigation links dynamically based on auth state
-  const navLinks = [
+  const navLinks: NavLink[] = [
     { name: "Home", path: "/", icon: Home },
-    ...(isAuthenticated ? [{ name: "Dashboard", path: "/dashboard", icon: LayoutDashboard }] : []),
+    ...(isAuthenticated
+      ? [
+          {
+            name: "Dashboard",
+            path: redirectDashboard ? EXTERNAL_DASHBOARD_URL : "/dashboard",
+            icon: LayoutDashboard,
+            external: redirectDashboard,
+          },
+        ]
+      : []),
     { name: "About", path: "/about", icon: Info },
     { name: "Pricing", path: "/pricing", icon: Tag },
     { name: "Rules", path: "/rules", icon: BookOpen },
@@ -85,32 +113,46 @@ const Navbar = () => {
 
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-8">
-            {navLinks.map((link) => (
-              <Link
-                key={link.path}
-                to={link.path}
-                onClick={handleLinkClick}
-                className={cn(
-                  "relative font-medium text-sm transition-all duration-300 hover:text-primary link-transition",
-                  location.pathname === link.path ||
-                    location.pathname.startsWith(link.path + "/")
-                    ? "text-primary"
-                    : "text-muted-foreground",
-                )}
-              >
-                {link.name}
-                <span
-                  className={cn(
-                    "absolute -bottom-1 left-0 h-0.5 transition-all duration-300",
-                    "bg-gradient-to-r from-gold-dark via-primary to-gold-light",
-                    location.pathname === link.path ||
-                      location.pathname.startsWith(link.path + "/")
-                      ? "w-full"
-                      : "w-0",
-                  )}
-                />
-              </Link>
-            ))}
+            {navLinks.map((link) => {
+              const active =
+                location.pathname === link.path ||
+                location.pathname.startsWith(link.path + "/");
+              const className = cn(
+                "relative font-medium text-sm transition-all duration-300 hover:text-primary link-transition",
+                active ? "text-primary" : "text-muted-foreground",
+              );
+              const inner = (
+                <>
+                  {link.name}
+                  <span
+                    className={cn(
+                      "absolute -bottom-1 left-0 h-0.5 transition-all duration-300",
+                      "bg-gradient-to-r from-gold-dark via-primary to-gold-light",
+                      active ? "w-full" : "w-0",
+                    )}
+                  />
+                </>
+              );
+              return link.external ? (
+                <a
+                  key={link.path}
+                  href={link.path}
+                  onClick={handleLinkClick}
+                  className={className}
+                >
+                  {inner}
+                </a>
+              ) : (
+                <Link
+                  key={link.path}
+                  to={link.path}
+                  onClick={handleLinkClick}
+                  className={className}
+                >
+                  {inner}
+                </Link>
+              );
+            })}
 
             {/* Help Center dropdown */}
             <DropdownMenu>
@@ -214,23 +256,38 @@ const Navbar = () => {
                       const active =
                         location.pathname === link.path ||
                         location.pathname.startsWith(link.path + "/");
-                      return (
-                        <Link
-                          key={link.path}
-                          to={link.path}
-                          onClick={handleLinkClick}
-                          className={cn(
-                            "flex items-center gap-3 px-4 py-3 rounded-xl font-medium text-sm transition-all duration-300",
-                            active
-                              ? "bg-primary/10 text-primary border border-primary/20"
-                              : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-                          )}
-                        >
+                      const className = cn(
+                        "flex items-center gap-3 px-4 py-3 rounded-xl font-medium text-sm transition-all duration-300",
+                        active
+                          ? "bg-primary/10 text-primary border border-primary/20"
+                          : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                      );
+                      const inner = (
+                        <>
                           <Icon
                             size={20}
                             className={active ? "text-primary" : ""}
                           />
                           <span>{link.name}</span>
+                        </>
+                      );
+                      return link.external ? (
+                        <a
+                          key={link.path}
+                          href={link.path}
+                          onClick={handleLinkClick}
+                          className={className}
+                        >
+                          {inner}
+                        </a>
+                      ) : (
+                        <Link
+                          key={link.path}
+                          to={link.path}
+                          onClick={handleLinkClick}
+                          className={className}
+                        >
+                          {inner}
                         </Link>
                       );
                     })}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -42,6 +42,20 @@ export const env = {
    */
   crispWebsiteId: import.meta.env.VITE_CRISP_WEBSITE_ID || '',
 
+  /**
+   * Temporary: when 'true', traders are redirected to the YPF-hosted dashboard
+   * (admin.dynastyfuturesdyn.com) instead of our in-app dashboard while our
+   * reset/activation checkout flows are still being finished. Flip to 'false'
+   * (or remove) to restore the in-app dashboard for everyone — no code change.
+   */
+  externalDashboardEnabled: import.meta.env.VITE_EXTERNAL_DASHBOARD === 'true',
+
+  /**
+   * Comma-separated emails that keep using our in-app dashboard even when
+   * externalDashboardEnabled is true (e.g. staff / test accounts).
+   */
+  dashboardAllowlist: import.meta.env.VITE_DASHBOARD_ALLOWLIST || '',
+
   /** True when running `npm run build` (NODE_ENV=production) */
   isProduction: import.meta.env.PROD,
 

--- a/src/lib/externalDashboard.ts
+++ b/src/lib/externalDashboard.ts
@@ -1,0 +1,43 @@
+// =============================================================================
+// External Dashboard Redirect (temporary)
+// =============================================================================
+// While our in-app reset/activation checkout flows are still being finished,
+// traders are redirected to the YPF-hosted dashboard at
+// admin.dynastyfuturesdyn.com, which supports those flows today.
+//
+// This whole module is a temporary gate. To revert:
+//   - Flip VITE_EXTERNAL_DASHBOARD to "false" (or remove it) in Vercel — no code
+//     deploy needed; everything below no-ops and the in-app dashboard returns.
+//   - Or git-revert the commit that introduced this file + its few call sites.
+//
+// A comma-separated allowlist of emails (VITE_DASHBOARD_ALLOWLIST) keeps specific
+// accounts (staff / test traders) on our in-app dashboard even while the redirect
+// is enabled.
+//
+// NOTE: this is a UI gate, not a security boundary — our dashboard is still
+// auth-protected. It only hides an unfinished surface, so a client-side email
+// allowlist is appropriate (manageable from Vercel without a code change).
+// =============================================================================
+
+import { env } from '@/config/env';
+
+/** The YPF-hosted dashboard traders are redirected to while ours is unfinished. */
+export const EXTERNAL_DASHBOARD_URL = 'https://admin.dynastyfuturesdyn.com';
+
+// Pre-computed lowercase email allowlist.
+const allowlist = new Set(
+  env.dashboardAllowlist
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+/**
+ * Whether the given user should be bounced to the external (YPF) dashboard.
+ * Returns false when the redirect is disabled or the user's email is allowlisted.
+ */
+export const shouldUseExternalDashboard = (email?: string | null): boolean => {
+  if (!env.externalDashboardEnabled) return false;
+  if (email && allowlist.has(email.toLowerCase())) return false;
+  return true;
+};


### PR DESCRIPTION
## Why

Our in-app **reset** and **activation** checkout flows aren't finished yet (blocked on a YPF `ypf-ref` mint endpoint). YPF's hosted dashboard at `admin.dynastyfuturesdyn.com` supports those flows today. Until we finish, send traders there — while keeping an **allowlist** so specific accounts can still use our in-app dashboard for testing.

**This PR ships the redirect ENABLED for production** (`VITE_EXTERNAL_DASHBOARD=true` in `.env.production`). Merging + deploying turns it on.

## How

- **`src/lib/externalDashboard.ts`** — single source of truth. Reads `VITE_EXTERNAL_DASHBOARD` (on/off) and `VITE_DASHBOARD_ALLOWLIST` (comma-separated emails that stay on our dashboard). `shouldUseExternalDashboard(email)` is the one helper both call sites use.
- **`ExternalDashboardGate`** (nested inside `ProtectedRoute`) — bounces non-allowlisted traders to the external URL. Catches **every** way into `/dashboard` — navbar, post-login redirect, direct URL / bookmark — so no other route code needs to change.
- **`Navbar`** — the "Dashboard" link points off-site (full-page `<a href>`) for redirected traders, in both desktop and mobile nav, so our dashboard never flashes before the gate fires.
- **`.env.production`** sets `VITE_EXTERNAL_DASHBOARD=true`; `env.ts` + `.env.example` document both vars.

## Allowlist (who keeps the DF dashboard)

`VITE_DASHBOARD_ALLOWLIST` is left **empty in the repo on purpose** — manage it in the **Vercel dashboard** so you can add/remove test accounts without a code change:

```
VITE_DASHBOARD_ALLOWLIST=you@dynastyfuturesdyn.com,tester@example.com
```

⚠️ It's a build-time var, so a Vercel **redeploy** is required after changing it. Set the allowlist **before** (or with) the deploy so you don't lock yourself out of the DF dashboard.

## Reversal (easy, by design)

- **Instant:** set `VITE_EXTERNAL_DASHBOARD=false` in Vercel (overrides `.env.production`) → the whole feature no-ops, in-app dashboard returns for everyone. Redeploy.
- **Per-account:** add an email to `VITE_DASHBOARD_ALLOWLIST` in Vercel.
- **Permanent:** `git revert` this one commit (one new module + a few small edits).

## Notes

- This is a **UI gate, not a security boundary** — the dashboard stays auth-protected (`ProtectedRoute`); we're only hiding an unfinished surface, so a client-side email allowlist is the right tool.

## Verification

- `npm run build` clean (flag on) — 11 routes prerendered.
- `npm run lint` at baseline (6 errors / 23 warnings, all pre-existing in `tailwind.config.ts` + exhaustive-deps elsewhere).
- `tsc --noEmit` — no new errors in touched files (10 pre-existing baseline errors unchanged).
