### PR TITLE
Add scheduled maintenance banner (weekdays 4:30–6 PM ET)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import ExternalDashboardGate from "@/components/auth/ExternalDashboardGate";
 import { getPerfFlags } from "@/lib/perfFlags";
 import CookieConsentBanner from "@/components/ui/CookieConsentBanner";
+import MaintenanceBanner from "@/components/ui/MaintenanceBanner";
 import CrispChat from "@/components/integrations/CrispChat";
 
 // Keep home route eagerly loaded; lazy-load the rest.
@@ -142,6 +143,7 @@ const App = () => {
               <Sonner />
               <CrispChat />
               <BrowserRouter>
+                <MaintenanceBanner />
                 <ScrollToTop />
                 <AppRoutes />
                 <CookieConsentBanner />

--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -34,7 +34,7 @@ const DashboardMobileNav = () => {
   };
 
   return (
-    <div className="lg:hidden fixed top-0 left-0 right-0 z-50 bg-card/80 backdrop-blur-xl border-b border-border/30">
+    <div className="lg:hidden fixed left-0 right-0 z-50 bg-card/80 backdrop-blur-xl border-b border-border/30" style={{ top: 'var(--maint-h, 0px)' }}>
       <div className="flex items-center justify-between p-4">
         <Link to="/" className="flex items-center gap-2">
           <img src={siteIconSrc} alt="Dynasty Futures" className="h-10 w-10 object-contain logo-blend" />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -24,7 +24,10 @@ const Layout = ({ children, hideFooter = false }: LayoutProps) => {
         <BackgroundScene beamCount={18} />
       </div>
       <Navbar />
-      <main className="flex-1 pt-16 md:pt-20 relative z-[1]">{children}</main>
+      <main
+        className="flex-1 relative z-[1]"
+        style={{ paddingTop: 'calc(var(--navbar-h) + var(--maint-h, 0px))' }}
+      >{children}</main>
       {!hideFooter && (
         <div className="relative z-[1]">
           <Footer />

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -95,7 +95,7 @@ const Navbar = () => {
   ];
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 glass border-b border-border/30">
+    <nav className="fixed left-0 right-0 z-50 glass border-b border-border/30" style={{ top: 'var(--maint-h, 0px)' }}>
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-28 md:h-40">
           {/* Logo */}

--- a/src/components/ui/MaintenanceBanner.tsx
+++ b/src/components/ui/MaintenanceBanner.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+
+const BANNER_HEIGHT = "2.5rem"; // h-10
+
+function isMaintenanceWindow(): boolean {
+  const now = new Date();
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    weekday: "short",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+  }).formatToParts(now);
+
+  const weekday = parts.find((p) => p.type === "weekday")?.value ?? "";
+  const hour = parseInt(parts.find((p) => p.type === "hour")?.value ?? "0", 10);
+  const minute = parseInt(parts.find((p) => p.type === "minute")?.value ?? "0", 10);
+
+  const isWeekday = !["Sat", "Sun"].includes(weekday);
+  const totalMinutes = hour * 60 + minute;
+  const windowStart = 16 * 60 + 30; // 4:30 PM
+  const windowEnd = 18 * 60;        // 6:00 PM
+
+  return isWeekday && totalMinutes >= windowStart && totalMinutes < windowEnd;
+}
+
+const MaintenanceBanner = () => {
+  const [active, setActive] = useState(() => isMaintenanceWindow());
+
+  useEffect(() => {
+    const tick = () => setActive(isMaintenanceWindow());
+    const id = setInterval(tick, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty(
+      "--maint-h",
+      active ? BANNER_HEIGHT : "0px"
+    );
+    return () => {
+      document.documentElement.style.setProperty("--maint-h", "0px");
+    };
+  }, [active]);
+
+  if (!active) return null;
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 z-[70] flex items-center justify-center gap-2 px-4 bg-amber-500 text-amber-950"
+      style={{ height: BANNER_HEIGHT }}
+      role="status"
+      aria-live="polite"
+    >
+      <AlertTriangle size={14} className="shrink-0" aria-hidden="true" />
+      <p className="text-xs font-semibold text-center">
+        Scheduled maintenance is currently in progress (4:30 PM – 6:00 PM ET, Mon–Fri). Some features may be temporarily unavailable.
+      </p>
+    </div>
+  );
+};
+
+export default MaintenanceBanner;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Maintenance banner height: set to 0 by default; MaintenanceBanner.tsx sets
+   --maint-h at runtime so navbars and content automatically shift down. */
+:root {
+  --maint-h: 0px;
+  --navbar-h: 4rem; /* matches pt-16 */
+}
+@media (min-width: 768px) {
+  :root {
+    --navbar-h: 5rem; /* matches pt-20 */
+  }
+}
+
 @layer base {
   :root {
     --background: 0 0% 4%;


### PR DESCRIPTION
## Summary

- Adds `MaintenanceBanner` component — a non-dismissable amber top bar that automatically shows on all pages during the maintenance window (Monday–Friday, 4:30 PM – 6:00 PM Eastern Time) and hides itself automatically when the window ends
- Polls every 30 seconds to check time, so the banner appears/disappears without a page reload
- Sets a CSS variable (`--maint-h`) on `:root` when active so the navbar and page content shift down cleanly — nothing is obscured
- Works across both the public site (`Layout`) and the dashboard (`DashboardLayout`)

## Files changed

| File | Change |
|---|---|
| `src/components/ui/MaintenanceBanner.tsx` | New component — time check logic + amber fixed banner |
| `src/App.tsx` | Mount `<MaintenanceBanner />` globally inside `BrowserRouter` |
| `src/components/layout/Navbar.tsx` | Navbar uses `top: var(--maint-h, 0px)` instead of `top-0` |
| `src/components/dashboard/DashboardMobileNav.tsx` | Same shift for mobile dashboard nav |
| `src/components/layout/Layout.tsx` | Main padding uses `calc(var(--navbar-h) + var(--maint-h, 0px))` |
| `src/index.css` | Defines `--navbar-h` (responsive: 4rem mobile / 5rem md+) and `--maint-h: 0px` default |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKL9TD9Rss6UW2eYY17hMK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKL9TD9Rss6UW2eYY17hMK)_