### PR TITLE
Un-hide Trade tab (Volumetrica embed live)

### DIFF
--- a/src/components/dashboard/DashboardMobileNav.tsx
+++ b/src/components/dashboard/DashboardMobileNav.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Menu, LayoutDashboard, Wallet, CalendarClock, CreditCard, Banknote, Users, User, Trophy, HelpCircle } from 'lucide-react';
+import { Menu, LayoutDashboard, Wallet, CandlestickChart, CalendarClock, CreditCard, Banknote, Users, User, Trophy, HelpCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 
@@ -8,11 +8,11 @@ import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 const siteIconSrc = '/favicon.png?v=20260406';
 
 // Order mirrors the desktop sidebar: primary items first, then Profile /
-// Affiliate / Help Center. 'Trade' stays hidden (launch via the "Launch
-// Platform" button); its route + page are kept for later.
+// Affiliate / Help Center. 'Trade' embeds the Volumetrica web-trader in-app.
 const sidebarLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Wallet },
+  { name: 'Trade', path: '/dashboard/trade', icon: CandlestickChart },
   { name: 'Billing', path: '/dashboard/billing', icon: CreditCard },
   { name: 'Payouts', path: '/dashboard/payouts', icon: Banknote },
   { name: 'Awards', path: '/dashboard/awards', icon: Trophy },

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   Activity,
   Briefcase,
+  CandlestickChart,
   CalendarClock,
   Receipt,
   ArrowDownToLine,
@@ -15,12 +16,13 @@ import { cn } from '@/lib/utils';
 
 const siteIconSrc = '/favicon.png?v=20260406';
 
-// Primary nav (top). 'Trade' stays hidden until the in-app Volumetrica embed is
-// unblocked — traders launch via the "Launch Platform" button. The
-// /dashboard/trade route + page are intentionally kept for when the embed works.
+// Primary nav (top). The in-app Volumetrica web-trader embed is live, so 'Trade'
+// renders the platform inside the dashboard; the "Launch Platform" button remains
+// as a new-tab fallback.
 const primaryLinks = [
   { name: 'Dashboard', path: '/dashboard', icon: Activity },
   { name: 'Accounts', path: '/dashboard/accounts', icon: Briefcase },
+  { name: 'Trade', path: '/dashboard/trade', icon: CandlestickChart },
   { name: 'Billing', path: '/dashboard/billing', icon: Receipt },
   { name: 'Payouts', path: '/dashboard/payouts', icon: ArrowDownToLine },
   { name: 'Awards', path: '/dashboard/awards', icon: Award },


### PR DESCRIPTION
## What

Restores the **Trade** entry in the desktop sidebar (`DashboardSidebar`) and mobile nav (`DashboardMobileNav`). The `/dashboard/trade` route, page, and iframe were kept in place when the tab was hidden (PR #18) — this just brings the entry back now that the in-app Volumetrica web-trader embed works.

## Why it's safe now

The embed was blocked because our Volumetrica key targeted the wrong org. YPF supplied a production key for the trader environment, validated end-to-end:

- `VolumetricaWebApp` mints `https://webapp.volumetricatrading.com?jtoken=…` for a real trader.
- Loaded in a real browser → **200**, renders the live trading platform.
- **Cross-origin iframe embed works** — no `X-Frame-Options` / CSP `frame-ancestors`; child frame reachable + rendered.

Pairs with **DF-Backend #42** (config repoint; Secrets Manager already updated). Build clean, 11 routes prerender.
