### PR TITLE
Dashboard parity: show backend-sourced payout cap on all plans

### DIFF
--- a/src/components/dashboard/BuilderPanel.tsx
+++ b/src/components/dashboard/BuilderPanel.tsx
@@ -239,8 +239,12 @@ const BuilderPanel = ({
                 icon={<Calendar size={14} className="text-gold-dark" />}
               />
               <DetailRow
-                label="Weekly Max"
-                value="$7,000"
+                label="Max Payout / Cycle"
+                value={
+                  account?.payoutCycleCap != null
+                    ? `$${account.payoutCycleCap.toLocaleString("en-US")}`
+                    : "—"
+                }
                 icon={<ArrowUpRight size={14} className="text-primary" />}
               />
             </>

--- a/src/components/dashboard/SummaryPanel.tsx
+++ b/src/components/dashboard/SummaryPanel.tsx
@@ -315,6 +315,13 @@ const SummaryPanel = ({
               icon={<Percent size={14} className="text-primary" />}
               variant="success"
             />
+            {account.payoutCycleCap != null && (
+              <SummaryItem
+                label="Max Payout / Cycle"
+                value={`$${account.payoutCycleCap.toLocaleString("en-US")}`}
+                icon={<ArrowUpRight size={14} className="text-primary" />}
+              />
+            )}
             {account.nextProgramName && (
               <SummaryItem
                 label="Next Phase"

--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -69,6 +69,9 @@ export interface AccountData {
   // Drives the per-trade running-equity curve so intraday dips/recoveries show
   // instead of collapsing trades into one daily step.
   closedTrades: ClosedTradePoint[];
+  // DF plan-level max payout per eligible payout cycle (from AccountType).
+  // Undefined = uncapped / not configured.
+  payoutCycleCap?: number;
   // Live platform fields (YPF) — only present on detail views with live data
   nextProgramName?: string;
   profitSplit?: number;

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -406,6 +406,9 @@ export const adaptAccountView = (
     stage: stageFor(account.status),
     status: uiStatusFor(account.status),
     startingBalance,
+    ...(account.accountType.payoutCycleCap != null
+      ? { payoutCycleCap: num(account.accountType.payoutCycleCap) }
+      : {}),
     profitTarget,
     maxDrawdown,
     dailyLossLimit,

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -20,6 +20,7 @@ export interface TradingAccountType {
   accountSize: string; // Prisma Decimal → string
   profitSplit: number;
   price: string; // Prisma Decimal → string
+  payoutCycleCap?: string | null; // Prisma Decimal → string; null = uncapped
 }
 
 export interface BillingChallenge {


### PR DESCRIPTION
## What

Gives every plan's dashboard a payout-cap line, **sourced from the backend** (no hardcoded numbers), so display == enforcement.

- **SummaryPanel** (Standard/Advanced) — new "Max Payout / Cycle" item.
- **BuilderPanel** — "Weekly Max $7,000" → "Max Payout / Cycle" from the account.
- Both read `account.payoutCycleCap`, mapped by `tradingAdapter` from `AccountType.payoutCycleCap` (returned on the account view). Shown only when present.

## Pairs with
**DF-Backend #45** (adds `AccountType.payoutCycleCap`, enforces it in the eligibility engine, exposes it on the account view). This FE PR shows `—` until that backend is deployed + the AccountTypes are re-seeded.

Marketing wording stays in **DF-Frontend #190** (Pricing/FAQ, static). Build clean, 11 routes prerender.
