### PR TITLE
Lower minimum withdrawal to $250 (marketing/legal wording)

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -2680,7 +2680,7 @@ const Legal = () => {
                         {[
                           { title: "5 Winning Days", desc: "You must have at least 5 trading days that meet the minimum winning day threshold since your last payout." },
                           { title: "Minimum Winning Day", desc: "Standard Plan: $150 minimum profit per qualifying day. Advanced & Builder: $200 minimum profit per qualifying day." },
-                          { title: "$500 Minimum Payout", desc: "The minimum payout amount is $500. You may withdraw up to 50% of your account balance per request." },
+                          { title: "$250 Minimum Payout", desc: "The minimum payout amount is $250. You may withdraw up to 50% of your account balance per request." },
                           { title: "5-Day Payout Cycles", desc: "At least 5 qualifying trading days must pass between payout requests. Up to 4 payout requests per calendar month." },
                         ].map(({ title, desc }) => (
                           <div key={title} className="p-5 rounded-xl border border-border/50 bg-muted/10">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -630,7 +630,7 @@ const Pricing = () => {
                           </div>
                         </td>
                         <td className="py-5 px-6 text-primary font-bold text-lg">
-                          $500
+                          $250
                         </td>
                         <td className="py-5 px-6 text-foreground font-semibold">
                           $5,000
@@ -655,7 +655,7 @@ const Pricing = () => {
                           </div>
                         </td>
                         <td className="py-5 px-6 text-gold-light font-bold text-lg">
-                          $500
+                          $250
                         </td>
                         <td className="py-5 px-6 text-foreground font-semibold">
                           $3,500
@@ -680,7 +680,7 @@ const Pricing = () => {
                           </div>
                         </td>
                         <td className="py-5 px-6 text-primary font-bold text-lg">
-                          $500
+                          $250
                         </td>
                         <td className="py-5 px-6 text-foreground font-semibold">
                           $3,000


### PR DESCRIPTION
## What

Updates the static minimum-withdrawal wording **$500 → $250** for all plans.

- **Pricing.tsx** — per-cycle minimum cells $500 → **$250** (Standard / Advanced / Builder).
- **Legal.tsx** — "**$250** Minimum Payout" (was $500).

## Why a fresh PR
The min wording was originally amended onto #190, but **#190 had already merged** — so it was stranded on the branch. This re-cuts it cleanly off current main (the cap wording from #190 is already in). Pairs with **DF-Backend #46** (enforcement). Build clean, 11 routes prerender.
