### PR TITLE
Update homepage Discord section (remove closed giveaways)

### DIFF
--- a/src/components/home/DiscordCTA.tsx
+++ b/src/components/home/DiscordCTA.tsx
@@ -16,29 +16,23 @@ const DiscordCTA = () => {
               </h2>
 
               <p className="text-lg text-muted-foreground mb-4 max-w-md">
-                Join the Dynasty Futures Discord and get involved before launch.
+                Join the Dynasty Futures Discord community for updates,
+                announcements, support guidance, and exclusive community offers.
               </p>
 
-              <p className="text-base text-muted-foreground mb-2 max-w-md">
-                We currently have <span className="text-foreground font-semibold">3 active pre-launch giveaways</span> with{" "}
-                <span className="text-foreground font-semibold">15 total Standard Accounts</span> being awarded:
+              <p className="text-base text-muted-foreground mb-4 max-w-md">
+                Our Discord members can access the current{" "}
+                <span className="text-foreground font-semibold">20% off discount code</span>{" "}
+                inside the{" "}
+                <span className="text-foreground font-semibold">#announcements</span>{" "}
+                channel.
               </p>
 
-              <ul className="text-base text-muted-foreground mb-4 max-w-md space-y-1 list-none">
-                <li>• 5 × $25K Standard Accounts</li>
-                <li>• 5 × $50K Standard Accounts</li>
-                <li>• 5 × $100K Standard Accounts</li>
-              </ul>
-
-              <p className="text-sm text-muted-foreground mb-4 max-w-md">
-                Winners will be announced on launch day.
+              <p className="text-base text-muted-foreground mb-6 max-w-md">
+                Stay connected with the team, follow launch updates, and make
+                sure you are checking announcements for the latest Dynasty
+                Futures information.
               </p>
-
-              <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full border border-gold/40 bg-gold/10 mb-6">
-                <span className="text-sm font-semibold text-gold">
-                  15 Winners&nbsp;•&nbsp;15 Accounts&nbsp;•&nbsp;Launch Day Announcement
-                </span>
-              </div>
 
               <Button
                 size="lg"


### PR DESCRIPTION
## What

The homepage Discord section still advertised the **pre-launch giveaways** and the **15 Standard Account winners**. Launch has happened and the giveaways are closed, so this removes that copy and refocuses the section on joining the community + accessing the discount code.

## Changes (`src/components/home/DiscordCTA.tsx`)

**Removed:**
- "3 active pre-launch giveaways / 15 total Standard Accounts" line
- The award bullet list (5×$25K / 5×$50K / 5×$100K)
- "Winners will be announced on launch day"
- The gold "15 Winners • 15 Accounts • Launch Day Announcement" badge

**Added:**
- Community intro (updates, announcements, support guidance, exclusive offers)
- Current **20% off discount code** available in the **#announcements** channel
- Stay-connected / check-announcements closing line

## Untouched (by request)
- "Join the Discord" heading
- The **button** — same `href`, label, and action
- The gold Discord icon

## Verification
`npm run build` clean — 11 routes prerendered.
