### PR TITLE
Trade tab cleanup + collapsible sidebar + mobile-friendly tables

### DIFF
--- a/src/components/dashboard/AccountTradeLog.tsx
+++ b/src/components/dashboard/AccountTradeLog.tsx
@@ -83,7 +83,65 @@ const AccountTradeLog = ({ accountId }: AccountTradeLogProps) => {
           <p className="text-sm">No trades on this account yet</p>
         </div>
       ) : (
-        <div className="max-h-[420px] overflow-auto">
+        <>
+        {/* Mobile: stacked cards (no horizontal scroll) */}
+        <div className="sm:hidden max-h-[420px] overflow-y-auto p-3 space-y-2.5">
+          {trades.map((trade) => {
+            const direction = trade.side === "BUY" ? "Long" : "Short";
+            const pnl = toNum(trade.realizedPnl) - toNum(trade.commission);
+            return (
+              <div
+                key={trade.id}
+                className="rounded-xl bg-muted/10 border border-border/30 p-3 space-y-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="font-medium text-foreground">
+                      {trade.symbol}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-xs font-medium px-1.5 py-0.5 rounded",
+                        direction === "Long"
+                          ? "text-emerald-500 bg-emerald-500/10"
+                          : "text-destructive bg-destructive/10",
+                      )}
+                    >
+                      {direction}
+                    </span>
+                  </div>
+                  <span
+                    className={cn(
+                      "font-semibold text-sm whitespace-nowrap",
+                      trade.realizedPnl === null
+                        ? "text-muted-foreground"
+                        : pnl >= 0
+                          ? "text-emerald-500"
+                          : "text-destructive",
+                    )}
+                  >
+                    {trade.realizedPnl !== null ? fmtCurrency(pnl) : "—"}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{fmtDateTime(trade.exitTime ?? trade.entryTime)}</span>
+                  <span>{fmtDuration(trade.entryTime, trade.exitTime)}</span>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>Qty {trade.quantity}</span>
+                  <span>Entry {toNum(trade.entryPrice).toFixed(2)}</span>
+                  <span>
+                    Exit{" "}
+                    {trade.exitPrice ? toNum(trade.exitPrice).toFixed(2) : "—"}
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* sm+: full table */}
+        <div className="hidden sm:block max-h-[420px] overflow-auto">
           <table className="w-full text-sm">
             <thead className="sticky top-0 bg-card/95 backdrop-blur-sm z-10">
               <tr className="border-b border-border/30">
@@ -168,6 +226,7 @@ const AccountTradeLog = ({ accountId }: AccountTradeLogProps) => {
             </tbody>
           </table>
         </div>
+        </>
       )}
     </div>
   );

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,9 +1,24 @@
+import { useEffect, useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
+import { PanelLeftOpen } from 'lucide-react';
 import DashboardSidebar from './DashboardSidebar';
 import DashboardMobileNav from './DashboardMobileNav';
 
 const SITE_NAME = 'Dynasty Futures';
+
+// Persist the collapsed state so a fuller-screen view (e.g. while trading)
+// survives navigation and refreshes until the trader reopens the sidebar.
+const SIDEBAR_COLLAPSED_KEY = 'df:sidebarCollapsed';
+
+const readCollapsed = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
 
 // Maps each dashboard route to the page name shown in the browser tab.
 const DASHBOARD_TITLES: Record<string, string> = {
@@ -30,6 +45,19 @@ const DashboardLayout = () => {
   const { pathname } = useLocation();
   const pageTitle = `${getDashboardTitle(pathname)} | ${SITE_NAME}`;
 
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean>(readCollapsed);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        SIDEBAR_COLLAPSED_KEY,
+        String(sidebarCollapsed),
+      );
+    } catch {
+      /* storage unavailable — non-fatal */
+    }
+  }, [sidebarCollapsed]);
+
   return (
     <div className="min-h-screen bg-background">
       <Helmet>
@@ -42,10 +70,25 @@ const DashboardLayout = () => {
       <DashboardMobileNav />
       
       <div className="flex">
-        {/* Desktop Sidebar */}
-        <div className="hidden lg:block">
-          <DashboardSidebar />
-        </div>
+        {/* Desktop Sidebar (collapsible) */}
+        {!sidebarCollapsed && (
+          <div className="hidden lg:block">
+            <DashboardSidebar onCollapse={() => setSidebarCollapsed(true)} />
+          </div>
+        )}
+
+        {/* Reopen button — shown on desktop when the sidebar is collapsed */}
+        {sidebarCollapsed && (
+          <button
+            type="button"
+            onClick={() => setSidebarCollapsed(false)}
+            aria-label="Open sidebar"
+            title="Open sidebar"
+            className="hidden lg:flex fixed left-3 top-3 z-40 items-center justify-center p-2 rounded-lg bg-card/70 border border-border/30 backdrop-blur-sm text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
+          >
+            <PanelLeftOpen size={18} />
+          </button>
+        )}
 
         {/* Main Content */}
         <main className="flex-1 min-h-screen">

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Award,
   Headphones,
   ExternalLink,
+  PanelLeftClose,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -36,7 +37,12 @@ const secondaryLinks = [
   { name: 'Help Center', path: '/dashboard/help', icon: Headphones },
 ];
 
-const DashboardSidebar = () => {
+interface DashboardSidebarProps {
+  /** When provided, renders a collapse button that hides the sidebar. */
+  onCollapse?: () => void;
+}
+
+const DashboardSidebar = ({ onCollapse }: DashboardSidebarProps) => {
   const location = useLocation();
 
   const isActive = (path: string) => {
@@ -72,7 +78,18 @@ const DashboardSidebar = () => {
   return (
     <aside className="w-52 shrink-0 h-screen sticky top-0 bg-transparent backdrop-blur-xl border-r border-border/30 flex flex-col overflow-hidden">
       {/* Logo + Home link */}
-      <div className="px-4 py-4 flex flex-col items-center gap-2 border-b border-border/20">
+      <div className="relative px-4 py-4 flex flex-col items-center gap-2 border-b border-border/20">
+        {onCollapse && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            aria-label="Collapse sidebar"
+            title="Collapse sidebar"
+            className="absolute top-2 right-2 p-1.5 rounded-lg text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
+          >
+            <PanelLeftClose size={16} />
+          </button>
+        )}
         <Link to="/" className="group">
           <img
             src={siteIconSrc}

--- a/src/pages/Payouts.tsx
+++ b/src/pages/Payouts.tsx
@@ -152,7 +152,30 @@ const Payouts = () => {
                     </h2>
                   </div>
 
-                  <div className="overflow-x-auto">
+                  {/* Mobile: stacked cards (no horizontal scroll) */}
+                  <div className="sm:hidden space-y-3">
+                    {mockData.payoutHistory.map((payout) => (
+                      <div
+                        key={payout.id}
+                        className="rounded-xl bg-muted/10 border border-border/30 p-4 flex items-center justify-between gap-3"
+                      >
+                        <div>
+                          <p className="text-foreground font-semibold">
+                            ${payout.amount.toLocaleString()}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {payout.date}
+                          </p>
+                        </div>
+                        <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                          {payout.status}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* sm+: full table */}
+                  <div className="hidden sm:block overflow-x-auto">
                     <table className="w-full">
                       <thead>
                         <tr className="border-b border-border/30">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -595,7 +595,70 @@ const Pricing = () => {
                 className="glass-card rounded-2xl border border-border/50 overflow-hidden"
                 delay={150}
               >
-                <div className="overflow-x-auto">
+                {/* Mobile: stacked cards (no horizontal scroll) */}
+                <div className="md:hidden p-4 space-y-3">
+                  {[
+                    {
+                      plan: "Standard",
+                      desc: "Monthly subscription, activation fee after pass",
+                      min: "$250",
+                      max: "$5,000",
+                      img: "standard" as const,
+                    },
+                    {
+                      plan: "Advanced",
+                      desc: "Monthly subscription, no activation fee",
+                      min: "$250",
+                      max: "$3,500",
+                      img: "advanced" as const,
+                    },
+                    {
+                      plan: "Builder",
+                      desc: "Higher max loss limit, no activation fee",
+                      min: "$250",
+                      max: "$3,000",
+                      img: "builder" as const,
+                    },
+                  ].map((row) => (
+                    <div
+                      key={row.plan}
+                      className="rounded-xl bg-muted/10 border border-border/30 p-4 space-y-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-9 h-9 rounded-xl bg-card/90 border border-border/30 flex items-center justify-center shrink-0">
+                          <PlanImage plan={row.img} size={26} />
+                        </div>
+                        <div className="min-w-0">
+                          <p className="font-semibold text-foreground">
+                            {row.plan}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {row.desc}
+                          </p>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-2 gap-3 text-sm">
+                        <div>
+                          <p className="text-xs text-muted-foreground mb-1">
+                            Minimum per Cycle
+                          </p>
+                          <p className="text-primary font-bold">{row.min}</p>
+                        </div>
+                        <div>
+                          <p className="text-xs text-muted-foreground mb-1">
+                            Maximum per Eligible Payout Cycle
+                          </p>
+                          <p className="text-foreground font-semibold">
+                            {row.max}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                {/* md+: full table */}
+                <div className="hidden md:block overflow-x-auto">
                   <table className="w-full">
                     <thead>
                       <tr className="border-b border-border/30 bg-muted/10">

--- a/src/pages/dashboard/DashboardAccounts.tsx
+++ b/src/pages/dashboard/DashboardAccounts.tsx
@@ -153,6 +153,67 @@ const ResetButton = ({ onClick }: { onClick: () => void }) => (
   </Button>
 );
 
+// Mobile card — a stacked, scroll-free view of one account. Replaces the
+// horizontally-overflowing table on small screens (the table only fits its
+// 6–7 columns on md+).
+const AccountCard = ({
+  account,
+  showBalance = false,
+  onReset,
+}: {
+  account: AccountView;
+  showBalance?: boolean;
+  onReset?: (account: AccountView) => void;
+}) => (
+  <div
+    className={`rounded-xl bg-card/50 backdrop-blur-sm border border-border/30 p-4 space-y-3 ${
+      account.status === "Active" ? "border-l-2 border-l-primary" : ""
+    }`}
+  >
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-foreground font-medium truncate">{account.planType}</p>
+        <p className="font-mono text-xs text-muted-foreground truncate">
+          {truncateId(account.id)}
+        </p>
+      </div>
+      <span
+        className={`shrink-0 px-2.5 py-1 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}
+      >
+        {account.status}
+      </span>
+    </div>
+
+    <div className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+      <div>
+        <p className="text-xs text-muted-foreground mb-1">Account Size</p>
+        <p className="text-foreground">{account.accountSize}</p>
+      </div>
+      <div>
+        <p className="text-xs text-muted-foreground mb-1">Stage</p>
+        <span
+          className={`inline-block px-2.5 py-1 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}
+        >
+          {account.stage}
+        </span>
+      </div>
+      {showBalance && (
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Balance</p>
+          <p className="text-foreground font-semibold">{account.balance}</p>
+        </div>
+      )}
+    </div>
+
+    <div className="flex items-center gap-2 pt-1">
+      {onReset && account.isResettable && (
+        <ResetButton onClick={() => onReset(account)} />
+      )}
+      <ViewButton id={account.id} />
+    </div>
+  </div>
+);
+
 const ActiveAccountsTable = ({ accounts }: { accounts: AccountView[] }) => {
   if (accounts.length === 0) {
     return (
@@ -164,53 +225,63 @@ const ActiveAccountsTable = ({ accounts }: { accounts: AccountView[] }) => {
   }
 
   return (
-    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow className="border-border/30 hover:bg-transparent">
-            <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Balance</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {accounts.map((account, index) => (
-            <TableRow
-              key={account.id}
-              className={`border-border/30 hover:bg-muted/20 transition-colors border-l-2 border-l-primary ${
-                index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
-              }`}
-            >
-              <TableCell className="font-mono text-xs text-muted-foreground py-4">
-                {truncateId(account.id)}
-              </TableCell>
-              <TableCell className="text-foreground py-4">{account.planType}</TableCell>
-              <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
-              <TableCell className="py-4">
-                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
-                  {account.stage}
-                </span>
-              </TableCell>
-              <TableCell className="py-4">
-                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
-                  {account.status}
-                </span>
-              </TableCell>
-              <TableCell className="font-semibold text-foreground py-4">{account.balance}</TableCell>
-              <TableCell className="text-right py-4">
-                <div className="flex items-center justify-end gap-2">
-                  <ViewButton id={account.id} />
-                </div>
-              </TableCell>
+    <>
+      {/* Mobile: stacked cards (no horizontal scroll) */}
+      <div className="md:hidden space-y-3">
+        {accounts.map((account) => (
+          <AccountCard key={account.id} account={account} showBalance />
+        ))}
+      </div>
+
+      {/* md+: full table */}
+      <div className="hidden md:block rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-border/30 hover:bg-transparent">
+              <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Balance</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {accounts.map((account, index) => (
+              <TableRow
+                key={account.id}
+                className={`border-border/30 hover:bg-muted/20 transition-colors border-l-2 border-l-primary ${
+                  index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+                }`}
+              >
+                <TableCell className="font-mono text-xs text-muted-foreground py-4">
+                  {truncateId(account.id)}
+                </TableCell>
+                <TableCell className="text-foreground py-4">{account.planType}</TableCell>
+                <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
+                <TableCell className="py-4">
+                  <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
+                    {account.stage}
+                  </span>
+                </TableCell>
+                <TableCell className="py-4">
+                  <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
+                    {account.status}
+                  </span>
+                </TableCell>
+                <TableCell className="font-semibold text-foreground py-4">{account.balance}</TableCell>
+                <TableCell className="text-right py-4">
+                  <div className="flex items-center justify-end gap-2">
+                    <ViewButton id={account.id} />
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 };
 
@@ -230,54 +301,64 @@ const InactiveAccountsTable = ({ accounts, onReset }: InactiveAccountsTableProps
   }
 
   return (
-    <div className="rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
-      <Table>
-        <TableHeader>
-          <TableRow className="border-border/30 hover:bg-transparent">
-            <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
-            <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {accounts.map((account, index) => (
-            <TableRow
-              key={account.id}
-              className={`border-border/30 hover:bg-muted/20 transition-colors ${
-                index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
-              }`}
-            >
-              <TableCell className="font-mono text-xs text-muted-foreground py-4">
-                {truncateId(account.id)}
-              </TableCell>
-              <TableCell className="text-foreground py-4">{account.planType}</TableCell>
-              <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
-              <TableCell className="py-4">
-                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
-                  {account.stage}
-                </span>
-              </TableCell>
-              <TableCell className="py-4">
-                <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
-                  {account.status}
-                </span>
-              </TableCell>
-              <TableCell className="text-right py-4">
-                <div className="flex items-center justify-end gap-2">
-                  {account.isResettable && (
-                    <ResetButton onClick={() => onReset(account)} />
-                  )}
-                  <ViewButton id={account.id} />
-                </div>
-              </TableCell>
+    <>
+      {/* Mobile: stacked cards (no horizontal scroll) */}
+      <div className="md:hidden space-y-3">
+        {accounts.map((account) => (
+          <AccountCard key={account.id} account={account} onReset={onReset} />
+        ))}
+      </div>
+
+      {/* md+: full table */}
+      <div className="hidden md:block rounded-2xl bg-card/50 backdrop-blur-sm border border-border/30 overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-border/30 hover:bg-transparent">
+              <TableHead className="text-muted-foreground font-medium py-4">Account ID</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Plan</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Account Size</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Stage</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4">Status</TableHead>
+              <TableHead className="text-muted-foreground font-medium py-4 text-right">Actions</TableHead>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+          </TableHeader>
+          <TableBody>
+            {accounts.map((account, index) => (
+              <TableRow
+                key={account.id}
+                className={`border-border/30 hover:bg-muted/20 transition-colors ${
+                  index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+                }`}
+              >
+                <TableCell className="font-mono text-xs text-muted-foreground py-4">
+                  {truncateId(account.id)}
+                </TableCell>
+                <TableCell className="text-foreground py-4">{account.planType}</TableCell>
+                <TableCell className="text-foreground py-4">{account.accountSize}</TableCell>
+                <TableCell className="py-4">
+                  <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStageBadge(account.stage)}`}>
+                    {account.stage}
+                  </span>
+                </TableCell>
+                <TableCell className="py-4">
+                  <span className={`px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusBadge(account.status)}`}>
+                    {account.status}
+                  </span>
+                </TableCell>
+                <TableCell className="text-right py-4">
+                  <div className="flex items-center justify-end gap-2">
+                    {account.isResettable && (
+                      <ResetButton onClick={() => onReset(account)} />
+                    )}
+                    <ViewButton id={account.id} />
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </>
   );
 };
 

--- a/src/pages/dashboard/DashboardBilling.tsx
+++ b/src/pages/dashboard/DashboardBilling.tsx
@@ -228,76 +228,101 @@ const DashboardBilling = () => {
               All account purchases
             </p>
           </div>
-          <Table>
-            <TableHeader>
-              <TableRow className="border-border/30 hover:bg-transparent">
-                <TableHead className="text-muted-foreground font-medium py-4">
-                  Date
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-4">
-                  Plan
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-4">
-                  Amount
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-4">
-                  Status
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <Loader2
-                      size={18}
-                      className="animate-spin text-muted-foreground mx-auto"
-                    />
-                  </TableCell>
-                </TableRow>
-              ) : accounts.length > 0 ? (
-                accounts.map((account) => (
-                  <TableRow
+          {isLoading ? (
+            <div className="py-12 text-center">
+              <Loader2
+                size={18}
+                className="animate-spin text-muted-foreground mx-auto"
+              />
+            </div>
+          ) : accounts.length === 0 ? (
+            <div className="py-16 text-center">
+              <div className="flex flex-col items-center gap-3">
+                <div className="p-4 rounded-2xl bg-muted/20 border border-border/20">
+                  <FileText size={28} className="text-muted-foreground/40" />
+                </div>
+                <p className="text-muted-foreground font-medium">
+                  No purchases yet
+                </p>
+                <p className="text-sm text-muted-foreground/60 max-w-xs mx-auto">
+                  Transactions will appear here after your first purchase.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Mobile: stacked cards (no horizontal scroll) */}
+              <div className="md:hidden p-4 space-y-3">
+                {accounts.map((account) => (
+                  <div
                     key={account.id}
-                    className="border-border/30 hover:bg-muted/10"
+                    className="rounded-xl bg-muted/10 border border-border/30 p-4 space-y-3"
                   >
-                    <TableCell className="py-4 text-muted-foreground">
-                      {formatDate(account.createdAt)}
-                    </TableCell>
-                    <TableCell className="py-4 font-medium text-foreground">
-                      {account.accountType.displayName}
-                    </TableCell>
-                    <TableCell className="py-4 font-semibold text-foreground">
-                      {getAmountPaid(account)}
-                    </TableCell>
-                    <TableCell className="py-4">
-                      <StatusBadge status={account.status} />
-                    </TableCell>
-                  </TableRow>
-                ))
-              ) : (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-16 text-center">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="p-4 rounded-2xl bg-muted/20 border border-border/20">
-                        <FileText
-                          size={28}
-                          className="text-muted-foreground/40"
-                        />
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-medium text-foreground truncate">
+                          {account.accountType.displayName}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatDate(account.createdAt)}
+                        </p>
                       </div>
-                      <p className="text-muted-foreground font-medium">
-                        No purchases yet
-                      </p>
-                      <p className="text-sm text-muted-foreground/60 max-w-xs">
-                        Transactions will appear here after your first
-                        purchase.
-                      </p>
+                      <StatusBadge status={account.status} />
                     </div>
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Amount</span>
+                      <span className="font-semibold text-foreground">
+                        {getAmountPaid(account)}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* md+: full table */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-border/30 hover:bg-transparent">
+                      <TableHead className="text-muted-foreground font-medium py-4">
+                        Date
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-4">
+                        Plan
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-4">
+                        Amount
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-4">
+                        Status
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {accounts.map((account) => (
+                      <TableRow
+                        key={account.id}
+                        className="border-border/30 hover:bg-muted/10"
+                      >
+                        <TableCell className="py-4 text-muted-foreground">
+                          {formatDate(account.createdAt)}
+                        </TableCell>
+                        <TableCell className="py-4 font-medium text-foreground">
+                          {account.accountType.displayName}
+                        </TableCell>
+                        <TableCell className="py-4 font-semibold text-foreground">
+                          {getAmountPaid(account)}
+                        </TableCell>
+                        <TableCell className="py-4">
+                          <StatusBadge status={account.status} />
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
         </div>
       </ScrollReveal>
     </div>

--- a/src/pages/dashboard/DashboardJournal.tsx
+++ b/src/pages/dashboard/DashboardJournal.tsx
@@ -388,7 +388,73 @@ const DashboardJournal = () => {
               </div>
 
               {dayTrades.length > 0 ? (
-                <div className="overflow-x-auto">
+                <>
+                {/* Mobile: stacked cards (no horizontal scroll) */}
+                <div className="sm:hidden space-y-2.5">
+                  {dayTrades.map((trade) => {
+                    const direction = trade.side === "BUY" ? "Long" : "Short";
+                    const pnl = Number(trade.realizedPnl ?? 0);
+                    return (
+                      <div
+                        key={trade.id}
+                        className="rounded-xl bg-muted/10 border border-border/30 p-3 space-y-2"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="font-medium text-foreground">
+                              {trade.symbol}
+                            </span>
+                            <span
+                              className={cn(
+                                "text-xs font-medium px-1.5 py-0.5 rounded",
+                                direction === "Long"
+                                  ? "text-primary bg-primary/10"
+                                  : "text-destructive bg-destructive/10",
+                              )}
+                            >
+                              {direction}
+                            </span>
+                          </div>
+                          <span
+                            className={cn(
+                              "font-semibold text-sm whitespace-nowrap",
+                              trade.realizedPnl === null
+                                ? "text-muted-foreground"
+                                : pnl >= 0
+                                  ? "text-primary"
+                                  : "text-destructive",
+                            )}
+                          >
+                            {trade.realizedPnl !== null
+                              ? formatCurrency(pnl)
+                              : "—"}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span>
+                            {formatTime(trade.entryTime)} →{" "}
+                            {trade.exitTime ? formatTime(trade.exitTime) : "Open"}
+                          </span>
+                          <span>
+                            {formatDuration(trade.entryTime, trade.exitTime)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                          <span>In {Number(trade.entryPrice).toFixed(2)}</span>
+                          <span>
+                            Out{" "}
+                            {trade.exitPrice
+                              ? Number(trade.exitPrice).toFixed(2)
+                              : "—"}
+                          </span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* sm+: full table */}
+                <div className="hidden sm:block overflow-x-auto">
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="border-b border-border/30">
@@ -477,6 +543,7 @@ const DashboardJournal = () => {
                     </tbody>
                   </table>
                 </div>
+                </>
               ) : (
                 <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
                   <Clock size={32} className="mb-3 opacity-40" />

--- a/src/pages/dashboard/DashboardPayouts.tsx
+++ b/src/pages/dashboard/DashboardPayouts.tsx
@@ -410,112 +410,185 @@ const DashboardPayouts = () => {
               </p>
             </div>
           </div>
-          <Table>
-            <TableHeader>
-              <TableRow className="border-border/30 hover:bg-transparent">
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Account
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Balance
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Available Profit
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5 text-right">
-                  Action
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {eligibleQ.isLoading ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <div className="flex items-center justify-center gap-2 text-muted-foreground">
-                      <Loader2 className="animate-spin" size={18} /> Loading
-                      accounts…
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ) : eligibleQ.isError ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <div className="flex flex-col items-center gap-2 text-destructive">
-                      <AlertCircle size={20} />
-                      <p className="text-sm">
-                        {eligibleQ.error?.message ??
-                          "Failed to load eligible accounts."}
-                      </p>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ) : eligibleAccounts.length === 0 ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="w-10 h-10 rounded-full bg-muted/30 flex items-center justify-center">
-                        <CircleOff size={20} className="text-muted-foreground/50" />
-                      </div>
-                      <p className="text-sm font-medium text-foreground">
-                        No funded accounts are currently eligible for payout.
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Eligible funded accounts will appear here once payout
-                        requirements are met.
-                      </p>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                eligibleAccounts.map((account, index) => (
-                  <TableRow
+          {eligibleQ.isLoading ? (
+            <div className="py-12 text-center">
+              <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                <Loader2 className="animate-spin" size={18} /> Loading accounts…
+              </div>
+            </div>
+          ) : eligibleQ.isError ? (
+            <div className="py-12 text-center">
+              <div className="flex flex-col items-center gap-2 text-destructive">
+                <AlertCircle size={20} />
+                <p className="text-sm">
+                  {eligibleQ.error?.message ??
+                    "Failed to load eligible accounts."}
+                </p>
+              </div>
+            </div>
+          ) : eligibleAccounts.length === 0 ? (
+            <div className="py-12 text-center">
+              <div className="flex flex-col items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-muted/30 flex items-center justify-center">
+                  <CircleOff size={20} className="text-muted-foreground/50" />
+                </div>
+                <p className="text-sm font-medium text-foreground">
+                  No funded accounts are currently eligible for payout.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Eligible funded accounts will appear here once payout
+                  requirements are met.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Mobile: stacked cards (no horizontal scroll) */}
+              <div className="md:hidden p-4 space-y-3">
+                {eligibleAccounts.map((account) => (
+                  <div
                     key={account.accountId}
-                    className={`border-border/30 hover:bg-muted/20 transition-colors ${
-                      index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
-                    }`}
+                    className="rounded-xl bg-muted/10 border border-border/30 p-4 space-y-3"
                   >
-                    <TableCell className="font-medium text-foreground py-6">
+                    <p className="font-medium text-foreground">
                       {account.accountName}
-                    </TableCell>
-                    <TableCell className="text-foreground py-6">
-                      {formatCurrency(account.currentBalance, account.currency)}
-                    </TableCell>
-                    <TableCell className="py-6">
-                      <span className="px-4 py-2 rounded-lg bg-primary/10 text-primary font-bold border border-primary/20">
-                        {formatCurrency(account.availableProfit, account.currency)}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right py-6">
+                    </p>
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Balance
+                        </p>
+                        <p className="text-foreground">
+                          {formatCurrency(
+                            account.currentBalance,
+                            account.currency,
+                          )}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Available Profit
+                        </p>
+                        <p className="text-primary font-bold">
+                          {formatCurrency(
+                            account.availableProfit,
+                            account.currency,
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="pt-1">
                       {account.hasPendingPayout ? (
                         <span className="text-xs text-muted-foreground">
                           Request in progress
                         </span>
                       ) : account.eligible ? (
-                        <Button size="sm" onClick={() => openModal(account)}>
+                        <Button
+                          size="sm"
+                          className="w-full"
+                          onClick={() => openModal(account)}
+                        >
                           Request Payout
                         </Button>
                       ) : (
-                        <div className="flex flex-col items-end gap-1">
+                        <div className="space-y-1">
                           <Button
                             size="sm"
                             variant="outline"
+                            className="w-full"
                             onClick={() => openModal(account)}
                           >
                             View Requirements
                           </Button>
                           {account.blockingReason && (
-                            <span className="text-[11px] text-muted-foreground max-w-[180px] text-right">
+                            <span className="block text-[11px] text-muted-foreground">
                               {account.blockingReason}
                             </span>
                           )}
                         </div>
                       )}
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* md+: full table */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-border/30 hover:bg-transparent">
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Account
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Balance
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Available Profit
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5 text-right">
+                        Action
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {eligibleAccounts.map((account, index) => (
+                      <TableRow
+                        key={account.accountId}
+                        className={`border-border/30 hover:bg-muted/20 transition-colors ${
+                          index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+                        }`}
+                      >
+                        <TableCell className="font-medium text-foreground py-6">
+                          {account.accountName}
+                        </TableCell>
+                        <TableCell className="text-foreground py-6">
+                          {formatCurrency(
+                            account.currentBalance,
+                            account.currency,
+                          )}
+                        </TableCell>
+                        <TableCell className="py-6">
+                          <span className="px-4 py-2 rounded-lg bg-primary/10 text-primary font-bold border border-primary/20">
+                            {formatCurrency(
+                              account.availableProfit,
+                              account.currency,
+                            )}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-right py-6">
+                          {account.hasPendingPayout ? (
+                            <span className="text-xs text-muted-foreground">
+                              Request in progress
+                            </span>
+                          ) : account.eligible ? (
+                            <Button size="sm" onClick={() => openModal(account)}>
+                              Request Payout
+                            </Button>
+                          ) : (
+                            <div className="flex flex-col items-end gap-1">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => openModal(account)}
+                              >
+                                View Requirements
+                              </Button>
+                              {account.blockingReason && (
+                                <span className="text-[11px] text-muted-foreground max-w-[180px] text-right">
+                                  {account.blockingReason}
+                                </span>
+                              )}
+                            </div>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
         </div>
 
         {/* Rise Works Info */}
@@ -564,69 +637,44 @@ const DashboardPayouts = () => {
               </p>
             </div>
           </div>
-          <Table>
-            <TableHeader>
-              <TableRow className="border-border/30 hover:bg-transparent">
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Request Date
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Amount
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Net Transfer
-                </TableHead>
-                <TableHead className="text-muted-foreground font-medium py-5">
-                  Status
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {historyQ.isLoading ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <div className="flex items-center justify-center gap-2 text-muted-foreground">
-                      <Loader2 className="animate-spin" size={18} /> Loading
-                      history…
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ) : payoutHistory.length === 0 ? (
-                <TableRow className="border-border/30 hover:bg-transparent">
-                  <TableCell colSpan={4} className="py-12 text-center">
-                    <div className="flex flex-col items-center gap-3">
-                      <div className="w-10 h-10 rounded-full bg-muted/30 flex items-center justify-center">
-                        <CircleOff size={20} className="text-muted-foreground/50" />
-                      </div>
-                      <p className="text-sm font-medium text-foreground">
-                        No payout history available.
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        Completed payout requests will appear here.
-                      </p>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                payoutHistory.map((payout: Payout, index) => (
-                  <TableRow
+          {historyQ.isLoading ? (
+            <div className="py-12 text-center">
+              <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                <Loader2 className="animate-spin" size={18} /> Loading history…
+              </div>
+            </div>
+          ) : payoutHistory.length === 0 ? (
+            <div className="py-12 text-center">
+              <div className="flex flex-col items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-muted/30 flex items-center justify-center">
+                  <CircleOff size={20} className="text-muted-foreground/50" />
+                </div>
+                <p className="text-sm font-medium text-foreground">
+                  No payout history available.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Completed payout requests will appear here.
+                </p>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Mobile: stacked cards (no horizontal scroll) */}
+              <div className="md:hidden p-4 space-y-3">
+                {payoutHistory.map((payout: Payout) => (
+                  <div
                     key={payout.id}
-                    className={`border-border/30 hover:bg-muted/20 transition-colors ${
-                      index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
-                    }`}
+                    className="rounded-xl bg-muted/10 border border-border/30 p-4 space-y-3"
                   >
-                    <TableCell className="font-medium text-foreground py-5">
-                      {new Date(payout.requestedAt).toLocaleDateString()}
-                    </TableCell>
-                    <TableCell className="font-bold text-foreground py-5">
-                      {formatCurrency(payout.amount, payout.currency)}
-                    </TableCell>
-                    <TableCell className="text-foreground py-5">
-                      {payout.transferAmount !== null
-                        ? formatCurrency(payout.transferAmount, payout.currency)
-                        : "—"}
-                    </TableCell>
-                    <TableCell className="py-5">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Requested
+                        </p>
+                        <p className="font-medium text-foreground">
+                          {new Date(payout.requestedAt).toLocaleDateString()}
+                        </p>
+                      </div>
                       <span
                         className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusStyle(payout.status)}`}
                         title={payout.rejectionReason ?? undefined}
@@ -634,12 +682,91 @@ const DashboardPayouts = () => {
                         {getStatusIcon(payout.status)}
                         {statusLabel[payout.status]}
                       </span>
-                    </TableCell>
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
+                    </div>
+                    <div className="grid grid-cols-2 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Amount
+                        </p>
+                        <p className="font-bold text-foreground">
+                          {formatCurrency(payout.amount, payout.currency)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">
+                          Net Transfer
+                        </p>
+                        <p className="text-foreground">
+                          {payout.transferAmount !== null
+                            ? formatCurrency(
+                                payout.transferAmount,
+                                payout.currency,
+                              )
+                            : "—"}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* md+: full table */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-border/30 hover:bg-transparent">
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Request Date
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Amount
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Net Transfer
+                      </TableHead>
+                      <TableHead className="text-muted-foreground font-medium py-5">
+                        Status
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {payoutHistory.map((payout: Payout, index) => (
+                      <TableRow
+                        key={payout.id}
+                        className={`border-border/30 hover:bg-muted/20 transition-colors ${
+                          index % 2 === 0 ? "bg-transparent" : "bg-muted/5"
+                        }`}
+                      >
+                        <TableCell className="font-medium text-foreground py-5">
+                          {new Date(payout.requestedAt).toLocaleDateString()}
+                        </TableCell>
+                        <TableCell className="font-bold text-foreground py-5">
+                          {formatCurrency(payout.amount, payout.currency)}
+                        </TableCell>
+                        <TableCell className="text-foreground py-5">
+                          {payout.transferAmount !== null
+                            ? formatCurrency(
+                                payout.transferAmount,
+                                payout.currency,
+                              )
+                            : "—"}
+                        </TableCell>
+                        <TableCell className="py-5">
+                          <span
+                            className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-medium border ${getStatusStyle(payout.status)}`}
+                            title={payout.rejectionReason ?? undefined}
+                          >
+                            {getStatusIcon(payout.status)}
+                            {statusLabel[payout.status]}
+                          </span>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
         </div>
       </ScrollReveal>
 

--- a/src/pages/dashboard/DashboardTrade.tsx
+++ b/src/pages/dashboard/DashboardTrade.tsx
@@ -1,42 +1,19 @@
-import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { Loader2, AlertCircle, ExternalLink } from 'lucide-react';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import ScrollReveal from '@/components/ui/ScrollReveal';
 import OpenPlatformButton from '@/components/dashboard/OpenPlatformButton';
 import { useTradingAccounts, useIframeUrl } from '@/hooks/useTrading';
 
 const DashboardTrade = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const accountsQ = useTradingAccounts();
   const accounts = accountsQ.data?.data ?? [];
+  const hasAccounts = accounts.length > 0;
 
-  const initial = searchParams.get('account') ?? '';
-  const [accountId, setAccountId] = useState<string>(initial);
-  // Default to first account once the list loads
-  if (!accountId && accounts.length > 0) {
-    setAccountId(accounts[0].id);
-  }
-
-  const updateAccount = (id: string) => {
-    setAccountId(id);
-    if (id) {
-      searchParams.set('account', id);
-    } else {
-      searchParams.delete('account');
-    }
-    setSearchParams(searchParams, { replace: true });
-  };
-
-  const iframeQ = useIframeUrl(accountId || undefined, {
-    enabled: !!accountId,
-  });
+  // The embed is the full Volumetrica web platform, which has its own built-in
+  // account switcher — so we mint a single user-scoped session and let the
+  // trader change accounts inside the platform itself. (A DF-side dropdown
+  // can't reliably re-scope the embed, since the minted session is keyed to the
+  // trader, not an individual account.)
+  const iframeQ = useIframeUrl(undefined, { enabled: hasAccounts });
   const iframeUrl = iframeQ.data?.data.url;
 
   return (
@@ -46,26 +23,11 @@ const DashboardTrade = () => {
           <div>
             <h1 className="text-2xl font-bold text-foreground">Trade</h1>
             <p className="text-muted-foreground mt-1">
-              Live trading via DeepCharts, embedded right here.
+              Live trading via DeepCharts, embedded right here. Switch between
+              your accounts directly inside the platform.
             </p>
           </div>
-          <div className="flex items-center gap-3">
-            {accounts.length > 0 && (
-              <Select value={accountId} onValueChange={updateAccount}>
-                <SelectTrigger className="w-[260px] bg-card/50 border-border/30 backdrop-blur-sm rounded-xl">
-                  <SelectValue placeholder="Select account" />
-                </SelectTrigger>
-                <SelectContent>
-                  {accounts.map((a) => (
-                    <SelectItem key={a.id} value={a.id}>
-                      {a.accountType.displayName || a.accountType.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <OpenPlatformButton variant="outline" size="default" />
-          </div>
+          <OpenPlatformButton variant="outline" size="default" />
         </div>
       </ScrollReveal>
 
@@ -77,21 +39,21 @@ const DashboardTrade = () => {
       )}
 
       {/* No accounts */}
-      {!accountsQ.isLoading && accounts.length === 0 && (
+      {!accountsQ.isLoading && !hasAccounts && (
         <div className="rounded-2xl border border-border/30 bg-card/50 p-8 text-center text-muted-foreground">
           You don't have any trading accounts yet.
         </div>
       )}
 
       {/* iFrame */}
-      {accountId && iframeQ.isLoading && (
+      {hasAccounts && iframeQ.isLoading && (
         <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm flex items-center justify-center min-h-[600px] text-muted-foreground">
           <Loader2 className="animate-spin mr-2" size={18} /> Connecting to
           trading platform…
         </div>
       )}
 
-      {accountId && iframeQ.isError && (
+      {hasAccounts && iframeQ.isError && (
         <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 flex items-start gap-3">
           <AlertCircle className="text-destructive shrink-0 mt-0.5" size={20} />
           <div className="flex-1">
@@ -106,7 +68,7 @@ const DashboardTrade = () => {
         </div>
       )}
 
-      {accountId && iframeUrl && (
+      {hasAccounts && iframeUrl && (
         <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm overflow-hidden">
           <iframe
             src={iframeUrl}


### PR DESCRIPTION
## What

Three related dashboard/UX fixes bundled together.

### 1. Trade tab — removed the account dropdown
The Trade tab had its own bare account `<Select>` (scattered, unstyled) that **didn't change the embedded Volumetrica view** when switched. The embed is the full Volumetrica web platform — which has its own built-in account switcher — and the minted session is keyed to the *trader*, not an individual account (per-account scoping would require YPF to populate `VolumetricaAccountId`, which it doesn't reliably do). So a DF-side dropdown couldn't reliably re-scope the embed.

**Fix:** dropped the dropdown entirely; the page now mints a single user-scoped session and traders switch accounts inside the platform. Kept the "Launch Platform" button and all loading/error/no-account states.

### 2. Collapsible sidebar
Added a collapse button (top-right of the dashboard sidebar) to hide it for a fuller-screen view (useful while trading in the embed). A floating reopen button restores it. Collapsed state persists via `localStorage` (`df:sidebarCollapsed`) across navigation/refresh. Desktop-only — mobile already uses the separate hamburger nav.

### 3. Mobile-friendly data tables (no more horizontal scroll)
Multi-column tables forced left/right scrolling on phones to read a single row. Each now renders as **stacked cards on mobile** and the **full table on `md`+ (or `sm`+)**:

- **Accounts** — Active + Inactive tables → shared `AccountCard`
- **Billing** — billing history
- **Payouts (dashboard)** — eligible accounts + payout history
- **Dashboard Home** — Trade Log (8-col)
- **Journal** — day-trades table (8-col)
- **Pricing** — Payout Limits table
- **Payouts (public)** — payout history

**Intentionally left as-is:** the Legal page's dense reference/comparison tables (drawdown, consistency, profit targets, etc.) keep their contained `overflow-x-auto` — horizontal scroll is the conventional, acceptable pattern for legal comparison data, and cards would hurt side-by-side comparability.

## Verification
`npm run build` clean — 11 routes prerendered. Lint at repo baseline (no new errors/warnings).
