### PR TITLE
Fix mobile profit-target badge + collapsed-sidebar button overlaps

### DIFF
--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -90,9 +90,10 @@ const DashboardLayout = () => {
           </button>
         )}
 
-        {/* Main Content */}
+        {/* Main Content. When the sidebar is collapsed, pad the content left on
+            desktop so the fixed reopen button never overlaps the page heading. */}
         <main className="flex-1 min-h-screen">
-          <div className="p-6 lg:p-8">
+          <div className={`p-6 lg:p-8 ${sidebarCollapsed ? "lg:pl-20" : ""}`}>
             <Outlet />
           </div>
         </main>

--- a/src/components/dashboard/PerformanceChart.tsx
+++ b/src/components/dashboard/PerformanceChart.tsx
@@ -188,7 +188,7 @@ const PerformanceChart = ({
           target is still above the chart; flips to a green "✓ target reached"
           once equity climbs to it. */}
       {chartType === "equity" && hasTarget && (
-        <div className="absolute top-10 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+        <div className="absolute top-16 sm:top-10 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
           <div
             className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold border ${
               targetReached


### PR DESCRIPTION
## What

Two positioning collisions reported after the last dashboard/mobile pass.

### 1. Mobile — profit-target badge overlapped the chart header
On the Account Performance card, the "▲ Target $Xk" badge is pinned to the top of the chart, centered. On desktop it clears the left-aligned title and right-aligned Equity/P&L toggle by sitting in the gap between them — but on narrow mobile widths that gap closes and the badge overlapped the header/toggle.

**Fix:** push the badge down on mobile only (`top-16 sm:top-10`) so it sits below the header row. Desktop position unchanged.

### 2. Desktop — collapsed-sidebar reopen button overlapped the page heading
When the sidebar is collapsed, the fixed reopen button (`top-3 left-3`) sat on top of the page `<h1>` (e.g. "Trade", "Dashboard").

**Fix:** when collapsed, add left padding to the main content on desktop (`lg:pl-20`) so the heading clears the button. No effect when the sidebar is expanded.

## Verification
`npm run build` clean — 11 routes prerendered. Lint at repo baseline.
