### PR TITLE
Update 150K profit target from $8,000 to $9,000

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -113,7 +113,7 @@ const faqs = [
     id: "profit-target",
     question: "What is the profit target?",
     answer:
-      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $8,000. Once you reach your profit target while following all rules, you pass the challenge.",
+      "The profit target varies by account size. For $25K accounts it's $1,500, for $50K accounts it's $3,000, for $100K accounts it's $6,000, and for $150K accounts it's $9,000. Once you reach your profit target while following all rules, you pass the challenge.",
   },
   {
     id: "profit-split",

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -2180,7 +2180,7 @@ const Legal = () => {
                                 { size: "25K", target: "$1,500", stdLoss: "$1,000", builderLoss: "$1,500", dll: "$750" },
                                 { size: "50K", target: "$3,000", stdLoss: "$2,000", builderLoss: "$2,500", dll: "$1,500" },
                                 { size: "100K", target: "$6,000", stdLoss: "$2,500", builderLoss: "$3,500", dll: "$2,000" },
-                                { size: "150K", target: "$8,000", stdLoss: "$4,000", builderLoss: "$5,000", dll: "$3,000" },
+                                { size: "150K", target: "$9,000", stdLoss: "$4,000", builderLoss: "$5,000", dll: "$3,000" },
                               ].map((row, i) => (
                                 <tr key={row.size} className={`border-b border-border/30 ${i % 2 === 0 ? "bg-muted/5" : ""}`}>
                                   <td className="px-4 py-3 font-semibold text-foreground">{row.size}</td>
@@ -2632,7 +2632,7 @@ const Legal = () => {
                               { size: "25K", target: "$1,500", funded: "No target" },
                               { size: "50K", target: "$3,000", funded: "No target" },
                               { size: "100K", target: "$6,000", funded: "No target" },
-                              { size: "150K", target: "$8,000", funded: "No target" },
+                              { size: "150K", target: "$9,000", funded: "No target" },
                             ].map((row, i) => (
                               <tr key={row.size} className={`border-b border-border/30 ${i % 2 === 0 ? "bg-muted/5" : ""}`}>
                                 <td className="px-4 py-3 font-semibold text-foreground">{row.size}</td>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -154,7 +154,7 @@ const standardAdvancedRules = {
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$8,000",
+    profitTarget: "$9,000",
     maxDrawdown: "$4,000",
     dailyLoss: "$3,000",
   },
@@ -177,7 +177,7 @@ const builderRules = {
     dailyLoss: "$2,000",
   },
   "$150,000": {
-    profitTarget: "$8,000",
+    profitTarget: "$9,000",
     maxDrawdown: "$5,000",
     dailyLoss: "$3,000",
   },

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -187,7 +187,7 @@ const accountRules = [
   },
   {
     size: "150K Account",
-    profitTarget: "$8,000",
+    profitTarget: "$9,000",
     standardAdvancedMaxDrawdown: "$4,000",
     builderMaxDrawdown: "$5,000",
     dailyLoss: "$3,000",


### PR DESCRIPTION
## Summary

- Updated the 150K account profit target from $8,000 to $9,000 across all relevant pages
- No other account sizes (25K, 50K, 100K) or other values (drawdown, DLL, pricing) were changed

## Files Changed

- `src/pages/Pricing.tsx` — 2 instances (Standard and Builder plan configs)
- `src/pages/Rules.tsx` — 1 instance (150K row in rules table)
- `src/pages/FAQ.tsx` — 1 instance (profit target FAQ answer)
- `src/pages/Legal.tsx` — 2 instances (Help & Legal Center tables)

---
_Generated by [Claude Code](https://claude.ai/code/session_019qLjzXGLrGctXskgcGaP4w)_