### PR TITLE
Add compliance rules: account ownership, IP compliance, hedging, min trade duration

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -127,6 +127,30 @@ const faqs = [
     answer:
       "After five approved payouts, Dynasty Futures may internally review the account for potential live trading consideration. Reviews may include trading consistency, compliance history, payout history, risk management, operational availability, and jurisdictional eligibility. Transition to a live environment is not guaranteed and remains at the sole discretion of Dynasty Futures.",
   },
+  {
+    id: "account-ownership",
+    question: "Can someone else trade my account?",
+    answer:
+      "No. All accounts must be traded exclusively by the original purchaser and registered account holder. Purchasing an account for another person, allowing another individual to trade on your behalf, sharing account credentials, or otherwise transferring account control is strictly prohibited. Violations may result in account review, suspension, payout denial, account termination, or loss of funded eligibility.",
+  },
+  {
+    id: "shared-ip",
+    question: "Can multiple traders use the same IP address?",
+    answer:
+      "Shared IP addresses may be reviewed for compliance purposes. Dynasty Futures monitors account activity and may request verification when account activity appears related or coordinated. Multiple traders operating from the same IP address, device, network, VPN environment, or location may be subject to additional review.",
+  },
+  {
+    id: "hedging",
+    question: "Is hedging allowed?",
+    answer:
+      "No. Hedging is prohibited within the Dynasty Futures ecosystem. This includes hedging across Dynasty Futures accounts, hedging between accounts owned by different individuals, coordinated trading activity designed to offset risk, and correlated offsetting positions. Accounts identified as participating in hedging activity may be subject to investigation, payout denial, funded-status review, account suspension, or account termination.",
+  },
+  {
+    id: "min-trade-duration",
+    question: "Is there a minimum trade duration?",
+    answer:
+      "Yes. Trades should remain open for a minimum of 10 seconds. Consistently opening and closing trades in under 10 seconds may negatively impact funded eligibility, payout eligibility, or account approval decisions. Dynasty Futures reserves the right to review accounts that demonstrate excessive ultra-short-duration trading activity.",
+  },
 ];
 
 const FAQ = () => {

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -161,6 +161,28 @@ const universalRules = [
       "All trades must be held for a minimum of ten (10) seconds. Trading activity that consistently enters and exits positions in less than ten seconds may impact funded status eligibility, payout eligibility, or continued participation in Dynasty Futures programs. Dynasty Futures reserves the right to review trading activity and determine compliance with the intended purpose of the evaluation and funded account programs.",
     allowed: false,
   },
+  {
+    icon: Lock,
+    title: "Account Ownership Requirement",
+    description:
+      "All Dynasty Futures accounts must be traded solely by the individual who purchased and registered the account. Purchasing an account for another person, allowing another individual to trade on your behalf, sharing account credentials, or otherwise transferring account control is strictly prohibited. Accounts must remain under the control of the original account holder at all times. Violations may result in account review, suspension, payout denial, account termination, or loss of funded eligibility.",
+    allowed: false,
+  },
+  {
+    icon: ShieldIcon,
+    title: "IP Address & Device Compliance",
+    description:
+      "Dynasty Futures monitors account activity for compliance and risk management purposes. Multiple traders operating from the same IP address, device, network, VPN environment, or location may be subject to additional review. Users may be asked to verify account ownership and trading activity when unusual account relationships or coordinated trading behavior are detected. Activity designed to circumvent account ownership rules, create artificial trading performance, manipulate evaluations, or coordinate trading between multiple individuals may result in account restrictions, payout review, funded-status review, or account termination.",
+    allowed: false,
+  },
+  {
+    icon: TrendingDown,
+    title: "Hedging Policy",
+    label: "Hedging Prohibited",
+    description:
+      "Hedging is prohibited within the Dynasty Futures ecosystem. This includes hedging positions between multiple Dynasty Futures accounts; hedging positions between accounts owned by different individuals; coordinated trading designed to offset risk across multiple traders; hedging correlated assets with the intent of reducing or eliminating market exposure; and trading opposite positions across accounts using shared IP addresses, shared devices, shared households, shared business entities, or coordinated groups. Accounts identified as participating in hedging activity may be subject to investigation, payout denial, funded-status review, account suspension, or account termination.",
+    allowed: false,
+  },
 ];
 
 const accountRules = [


### PR DESCRIPTION
## Summary

- **Rules page**: Added 3 new rules to the Universal Rules section — Account Ownership Requirement, IP Address & Device Compliance, and Hedging Policy (all categorized as Restricted & Prohibited). The Minimum Trade Duration rule already existed and was not duplicated.
- **FAQ page**: Added 4 new FAQ entries — "Can someone else trade my account?", "Can multiple traders use the same IP address?", "Is hedging allowed?", and "Is there a minimum trade duration?" — following existing styling and accordion structure.
- All existing rules and FAQ entries are preserved; no content was removed or restructured.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ldtth9EmpGxG9CGE4XUsQ5)_