### PR TITLE
Fix Daily Loss Limit: evaluation-only hard breach, account closes on hit

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -62,10 +62,16 @@ const faqs = [
       "We support connections to platforms like Volumetrica with DeepCharts data feed integration. These are third-party platforms and feeds—Dynasty Futures is a proprietary trading firm, not a brokerage.",
   },
   {
+    id: "daily-loss-limit",
+    question: "Does the Daily Loss Limit close my account?",
+    answer:
+      "Yes. The Daily Loss Limit applies to Standard Plan evaluation accounts only. If the Daily Loss Limit is hit or exceeded during the evaluation phase, it is a hard breach and the account will be closed. It does not apply to Advanced or Builder plans, and it does not apply to funded accounts.",
+  },
+  {
     id: "rule-violation",
     question: "What happens if I break a rule?",
     answer:
-      "If you violate any of the trading rules (such as exceeding the daily loss limit, Max Loss Limit, holding over the weekend, or trading during high-impact news), your account may be flagged or terminated depending on the severity. Always review the rules carefully before trading.",
+      "If you violate any of the trading rules (such as exceeding the Daily Loss Limit on a Standard evaluation account, Max Loss Limit, holding over the weekend, or trading during high-impact news), your account may be flagged or closed depending on the severity. Always review the rules carefully before trading.",
   },
   {
     id: "news-trading",

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -2237,7 +2237,7 @@ const Legal = () => {
                               <li className="flex gap-2"><span className="w-1.5 h-1.5 rounded-full bg-primary/60 mt-1.5 flex-shrink-0" />Static (fixed) drawdown</li>
                               <li className="flex gap-2"><span className="w-1.5 h-1.5 rounded-full bg-primary/60 mt-1.5 flex-shrink-0" />No profit target</li>
                               <li className="flex gap-2"><span className="w-1.5 h-1.5 rounded-full bg-primary/60 mt-1.5 flex-shrink-0" />Consistency rule: Builder only (40%)</li>
-                              <li className="flex gap-2"><span className="w-1.5 h-1.5 rounded-full bg-primary/60 mt-1.5 flex-shrink-0" />Daily loss limit: Standard only</li>
+                              <li className="flex gap-2"><span className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 mt-1.5 flex-shrink-0" />No daily loss limit (evaluation-only rule)</li>
                             </ul>
                           </div>
                         </div>
@@ -2289,18 +2289,18 @@ const Legal = () => {
                 )}
 
                 {/* ── DAILY LOSS LIMIT ── */}
-                {activeRule === "daily-loss" && (
+                {activeRule === "daily-loss-limit" && (
                   <div className="bg-gradient-card rounded-3xl border border-border/50 p-8 md:p-10 space-y-8">
                     <button onClick={() => handleSetActiveRule(null)} className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors mb-2">← Back to Trading Rules Overview</button>
                     <div>
                       <h2 className="font-display text-2xl font-bold text-foreground mb-3">Daily Loss Limit Explained</h2>
-                      <p className="text-sm text-muted-foreground leading-relaxed">The Daily Loss Limit (DLL) applies to the <strong className="text-foreground">Standard Plan only</strong> and is active during both the evaluation and funded phases. It caps how much you can lose in a single trading day, providing an additional layer of risk management on top of the Maximum Loss Limit.</p>
+                      <p className="text-sm text-muted-foreground leading-relaxed">The Daily Loss Limit (DLL) applies only to <strong className="text-foreground">Standard Plan evaluation accounts</strong>. If the Daily Loss Limit is hit or exceeded during the evaluation phase, it is considered a hard breach and the account will be closed. It does not apply to Advanced or Builder plans, and it does not apply to funded accounts.</p>
                     </div>
-                    <div className="p-4 rounded-xl border border-primary/30 bg-primary/5 text-sm text-muted-foreground">
-                      <strong className="text-foreground">Important:</strong> The DLL applies to Standard Plan accounts in both the evaluation and funded phases. Advanced and Builder plan accounts do not have a Daily Loss Limit.
+                    <div className="p-4 rounded-xl border border-destructive/30 bg-destructive/5 text-sm text-muted-foreground">
+                      <strong className="text-foreground">Hard Breach:</strong> Hitting or exceeding the Daily Loss Limit during evaluation is a hard breach. The account is closed immediately. Traders are responsible for monitoring their daily P&L and stopping before the limit is reached.
                     </div>
                     <div>
-                      <h3 className="font-display text-lg font-semibold text-foreground mb-4">Daily Loss Limit by Account Size (Standard Plan)</h3>
+                      <h3 className="font-display text-lg font-semibold text-foreground mb-4">Daily Loss Limit by Account Size (Standard Plan Evaluation Only)</h3>
                       <div className="overflow-x-auto rounded-xl border border-border/50">
                         <table className="w-full text-sm">
                           <thead>
@@ -2330,7 +2330,7 @@ const Legal = () => {
                       <div className="grid sm:grid-cols-2 gap-4">
                         <div className="p-5 rounded-xl border border-border/50 bg-muted/10">
                           <p className="text-sm font-semibold text-foreground mb-2">Daily Loss Limit (DLL)</p>
-                          <p className="text-sm text-muted-foreground leading-relaxed">A per-day loss cap. If your account loses the DLL amount within a single trading day, your account is in violation and no further trading is permitted that day. Resets each trading day.</p>
+                          <p className="text-sm text-muted-foreground leading-relaxed">A per-day loss cap that applies to Standard Plan evaluation accounts only. If the DLL is hit or exceeded during the evaluation phase, it is a hard breach and the account is closed. Advanced and Builder plans have no DLL.</p>
                         </div>
                         <div className="p-5 rounded-xl border border-border/50 bg-muted/10">
                           <p className="text-sm font-semibold text-foreground mb-2">Maximum Loss Limit (MLL)</p>
@@ -2342,10 +2342,10 @@ const Legal = () => {
                       <h3 className="font-display text-lg font-semibold text-foreground mb-4">Frequently Asked Questions</h3>
                       <div className="space-y-3">
                         {[
-                          { q: "Does the DLL apply on funded accounts?", a: "Yes. For Standard Plan accounts, the Daily Loss Limit applies in both the evaluation and funded phases." },
-                          { q: "Does the DLL reset each day?", a: "Yes. The DLL is calculated on a per-day basis and resets at the start of each new trading day." },
-                          { q: "What happens if I hit the DLL?", a: "Trading is halted for the remainder of that day. If losses also exceed the MLL, the account is terminated." },
-                          { q: "Do Advanced or Builder plans have a DLL?", a: "No. The Daily Loss Limit is exclusive to the Standard Plan." },
+                          { q: "Does the Daily Loss Limit close my account?", a: "Yes. The Daily Loss Limit applies to Standard Plan evaluation accounts only. If the Daily Loss Limit is hit or exceeded during the evaluation phase, it is a hard breach and the account will be closed." },
+                          { q: "Does the DLL apply on funded accounts?", a: "No. The Daily Loss Limit only applies during the Standard Plan evaluation phase. It does not apply to funded accounts." },
+                          { q: "Do Advanced or Builder plans have a DLL?", a: "No. The Daily Loss Limit is exclusive to Standard Plan evaluation accounts. Advanced and Builder plans have no Daily Loss Limit." },
+                          { q: "Who is responsible for monitoring the DLL?", a: "Traders are responsible for monitoring their own daily P&L and stopping before the Daily Loss Limit is reached. Hitting the limit is a hard breach with no appeal." },
                         ].map(({ q, a }) => (
                           <div key={q} className="p-5 rounded-xl border border-border/50 bg-muted/10">
                             <p className="text-sm font-semibold text-foreground mb-2">{q}</p>

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -134,6 +134,14 @@ const universalRules = [
   },
   {
     icon: TrendingDown,
+    title: "Daily Loss Limit (Standard Plan Evaluation Only)",
+    label: "Hard Breach — Account Closed",
+    description:
+      "The Daily Loss Limit applies only to Standard Plan evaluation accounts. If the Daily Loss Limit is hit or exceeded during the evaluation phase, it is a hard breach and the account will be closed immediately. Traders are responsible for monitoring their daily P&L and stopping before the limit is reached. The Daily Loss Limit does not apply to Advanced or Builder plans, and it does not apply to funded accounts.",
+    allowed: false,
+  },
+  {
+    icon: TrendingDown,
     title: "Post-Payout MLL Reset",
     description:
       "After a payout is processed, your Maximum Loss Limit (MLL) is reset to $0.00. Your remaining post-payout balance becomes your entire loss buffer. If losses reduce your account balance to $0.00 or below, the account is failed.",


### PR DESCRIPTION
## Summary

- **Fix broken button**: The "Daily Loss Limit Explained" card in Legal → Trading Rules was opening with no content because the `activeRule` check used `"daily-loss"` but the button set it to `"daily-loss-limit"`. Corrected the condition to match.
- **Rewrite DLL article**: Updated the article to clearly state DLL applies to Standard Plan evaluation accounts only, is a hard breach, and closes the account if hit or exceeded. Removed all language saying it applies to funded accounts or "blocks trading until reset."
- **Fix overview bullet**: Removed the incorrect "Daily loss limit: Standard only" bullet from the Funded Phase overview panel (DLL is evaluation-only, not funded).
- **Rules page**: Added a `Daily Loss Limit (Standard Plan Evaluation Only)` entry to the universal rules section with the correct hard breach / account closed policy language.
- **FAQ page**: Added new FAQ entry — "Does the Daily Loss Limit close my account?" — with the exact policy wording. Updated the existing rule-violation answer to reflect DLL closes Standard evaluation accounts.

## Files Changed

- `src/pages/Legal.tsx` — button routing fix, article rewrite, funded-phase bullet correction
- `src/pages/Rules.tsx` — new DLL universal rule entry
- `src/pages/FAQ.tsx` — new DLL FAQ entry, updated rule-violation answer

---
_Generated by [Claude Code](https://claude.ai/code/session_016itP4DEqrjBx4RgN59wi3V)_