### PR TITLE
Clarify Daily Loss Limit as Standard evaluation-only hard breach

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -387,6 +387,27 @@ const Legal = () => {
                     </div>
                   </div>
 
+                  {/* Daily Loss Limit */}
+                  <div>
+                    <h3 className="text-foreground font-display text-lg font-semibold mb-3">
+                      Daily Loss Limit / Daily Drawdown Rule
+                    </h3>
+                    <div className="space-y-3 text-muted-foreground text-sm leading-relaxed">
+                      <p>
+                        The Daily Loss Limit applies only to <strong className="text-foreground">Standard Plan evaluation accounts</strong>.
+                      </p>
+                      <p>
+                        If a Standard Plan evaluation account hits or exceeds the Daily Loss Limit at any point during the evaluation phase, it is considered a <strong className="text-foreground">hard breach</strong> and the account will be closed.
+                      </p>
+                      <p>
+                        The Daily Loss Limit does not apply to Advanced Plan accounts, Builder Plan accounts, or funded accounts unless otherwise stated by Dynasty Futures.
+                      </p>
+                      <p>
+                        Traders are responsible for monitoring their daily P&amp;L and managing risk before the Daily Loss Limit is reached.
+                      </p>
+                    </div>
+                  </div>
+
                   {/* 7. KYC, AML & Compliance Reviews */}
                   <div>
                     <h3 className="text-foreground font-display text-lg font-semibold mb-3">

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -364,6 +364,10 @@ const Pricing = () => {
         selectedPlan === "standard"
           ? (currentRules?.dailyLoss ?? "N/A")
           : "N/A",
+      note:
+        selectedPlan === "standard"
+          ? "Standard evaluation only. Hard breach. Account closes if hit."
+          : undefined,
     },
     {
       label: "Max Position Size",
@@ -546,7 +550,10 @@ const Pricing = () => {
                           )}
                         >
                           <td className="py-4 px-5 text-muted-foreground">
-                            {row.label}
+                            <span>{row.label}</span>
+                            {"note" in row && row.note && (
+                              <p className="text-xs text-amber-500/80 mt-0.5">{row.note}</p>
+                            )}
                           </td>
                           <td className="py-4 px-4 text-center font-semibold text-foreground">
                             {row.evaluation}
@@ -559,6 +566,12 @@ const Pricing = () => {
                     </tbody>
                   </table>
                 </div>
+
+                {selectedPlan === "standard" && (
+                  <p className="text-xs text-amber-500/80 mt-2 px-1">
+                    Daily Loss Limit applies to Standard Plan evaluation accounts only. Hitting or exceeding the Daily Loss Limit is a hard breach and will close the evaluation account.
+                  </p>
+                )}
 
                 {/* CTA */}
                 <div className="text-center">


### PR DESCRIPTION
## Summary

- **Terms of Use**: Added a dedicated "Daily Loss Limit / Daily Drawdown Rule" section under Trading Rules & Compliance (section 6), using the exact wording specified — clarifies it applies only to Standard Plan evaluations, is a hard breach, and does not apply to Advanced, Builder, or funded accounts.
- **Pricing page**: Added an inline amber-colored note beneath the "Daily Loss Limit" row label when the Standard Plan is selected ("Standard evaluation only. Hard breach. Account closes if hit."), and a disclaimer paragraph below the rules table visible only on the Standard Plan tab.

## What was NOT changed
- Advanced Plan rules
- Builder Plan rules
- Funded account rules
- Pricing values
- Payout rules
- Layout or styling beyond the added note/disclaimer text

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dku2f6wt3v7zQfZq834A1Y)_