### PR TITLE
Update Builder 150K Max Loss Limit from $5,000 to $4,500

### DIFF
--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -2201,7 +2201,7 @@ const Legal = () => {
                                 { size: "25K", target: "$1,500", stdLoss: "$1,000", builderLoss: "$1,500", dll: "$750" },
                                 { size: "50K", target: "$3,000", stdLoss: "$2,000", builderLoss: "$2,500", dll: "$1,500" },
                                 { size: "100K", target: "$6,000", stdLoss: "$2,500", builderLoss: "$3,500", dll: "$2,000" },
-                                { size: "150K", target: "$9,000", stdLoss: "$4,000", builderLoss: "$5,000", dll: "$3,000" },
+                                { size: "150K", target: "$9,000", stdLoss: "$4,000", builderLoss: "$4,500", dll: "$3,000" },
                               ].map((row, i) => (
                                 <tr key={row.size} className={`border-b border-border/30 ${i % 2 === 0 ? "bg-muted/5" : ""}`}>
                                   <td className="px-4 py-3 font-semibold text-foreground">{row.size}</td>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -178,7 +178,7 @@ const builderRules = {
   },
   "$150,000": {
     profitTarget: "$9,000",
-    maxDrawdown: "$5,000",
+    maxDrawdown: "$4,500",
     dailyLoss: "$3,000",
   },
 };

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -219,7 +219,7 @@ const accountRules = [
     size: "150K Account",
     profitTarget: "$9,000",
     standardAdvancedMaxDrawdown: "$4,000",
-    builderMaxDrawdown: "$5,000",
+    builderMaxDrawdown: "$4,500",
     dailyLoss: "$3,000",
   },
 ];


### PR DESCRIPTION
## Summary

- Updated Builder Plan 150K Max Loss Limit from **$5,000** to **$4,500** across all pages where it is displayed
- No other account sizes or plan limits were modified

## Files Changed

- **`src/pages/Pricing.tsx`** — `builderRules["$150,000"].maxDrawdown` updated
- **`src/pages/Rules.tsx`** — `builderMaxDrawdown` for the 150K Account entry updated
- **`src/pages/Legal.tsx`** — `builderLoss` in the 150K row of the account rules comparison table updated

## Verification

- ✓ Builder 150K Max Loss Limit now shows $4,500 everywhere
- ✓ No $5,000 Builder 150K references remain
- ✓ 25K, 50K, and 100K Builder limits unchanged
- ✓ Standard and Advanced plan limits unchanged
- ✓ Profit targets, daily loss limits, pricing, and payout rules unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnUMtE38LuL6zJTCKaq789)_