### PR TITLE
Update pricing and payout caps for Standard and Advanced plans

### DIFF
--- a/src/pages/FAQ.tsx
+++ b/src/pages/FAQ.tsx
@@ -35,7 +35,7 @@ const faqs = [
     id: "payouts",
     question: "When do payouts happen?",
     answer:
-      "For Standard, Advanced, and Builder plans, payouts occur on 5-day cycles once you're funded. Each plan has a maximum payout per request / eligible payout cycle after meeting 5 qualifying winning days — Standard $5,000, Advanced $3,500, and Builder $3,000. Payouts are processed through Rise Works after approval and may require standard verification before funds are released.",
+      "For Standard, Advanced, and Builder plans, payouts occur on 5-day cycles once you're funded. Each plan has a maximum payout per request / eligible payout cycle after meeting 5 qualifying winning days — Standard $3,000, Advanced $2,000, and Builder $3,000. Payouts are processed through Rise Works after approval and may require standard verification before funds are released.",
   },
   {
     id: "static-drawdown",

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -223,7 +223,7 @@ const planConfig: Record<
     label: "Standard Plan",
     tagline: "Pass First, Activate Later",
     description:
-      "Lower evaluation fee up front. If passed, a one-time $80 activation fee is required to activate your funded account.",
+      "Standard includes more structure and a higher payout cap ($3,000 per cycle), making it a strong option for traders who want a larger payout ceiling. Lower evaluation fee up front; a one-time $80 activation fee is required to activate your funded account.",
     evalConsistencyRule: "50%",
     fundedConsistencyRule: "None",
     pricing: standardPricing,
@@ -234,7 +234,7 @@ const planConfig: Record<
     label: "Advanced Plan",
     tagline: "Instant Activation, No Activation Fee",
     description:
-      "Pay once. When you pass, you're activated with no extra activation cost.",
+      "Advanced is designed to offer a faster and lower-friction path to funded status, including no activation fee and no consistency requirement. Because of that structure, Advanced carries a more conservative payout cap ($2,000 per cycle).",
     evalConsistencyRule: "None",
     fundedConsistencyRule: "None",
     pricing: advancedPricing,
@@ -615,14 +615,14 @@ const Pricing = () => {
                       plan: "Standard",
                       desc: "Monthly subscription, activation fee after pass",
                       min: "$250",
-                      max: "$5,000",
+                      max: "$3,000",
                       img: "standard" as const,
                     },
                     {
                       plan: "Advanced",
                       desc: "Monthly subscription, no activation fee",
                       min: "$250",
-                      max: "$3,500",
+                      max: "$2,000",
                       img: "advanced" as const,
                     },
                     {
@@ -709,7 +709,7 @@ const Pricing = () => {
                           $250
                         </td>
                         <td className="py-5 px-6 text-foreground font-semibold">
-                          $5,000
+                          $3,000
                         </td>
                       </tr>
                       <tr className="border-b border-border/20 hover:bg-primary/5 transition-colors">
@@ -734,7 +734,7 @@ const Pricing = () => {
                           $250
                         </td>
                         <td className="py-5 px-6 text-foreground font-semibold">
-                          $3,500
+                          $2,000
                         </td>
                       </tr>
                       <tr className="hover:bg-primary/5 transition-colors">

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -232,12 +232,12 @@ const planRules = [
       "Evaluation Fee + $80 Activation Fee (after passing)",
       "Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown.",
       "50% consistency rule (evaluation only)",
-      "5-day payout cycles",
+      "5-day payout cycles — maximum $3,000 per eligible payout cycle",
       "Copy trading allowed",
       "One funded reset allowed per account",
     ],
     eligibility:
-      "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $150 or more.",
+      "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $150 or more. Standard includes more structure and a higher payout cap, making it a strong option for traders who want a larger payout ceiling.",
   },
   {
     name: "Advanced Plan",
@@ -247,12 +247,12 @@ const planRules = [
       "Evaluations use trailing end-of-day drawdown. Funded accounts use static drawdown.",
       "No consistency rule",
       "Immediate activation",
-      "5-day payout cycles",
+      "5-day payout cycles — maximum $2,000 per eligible payout cycle",
       "Copy trading allowed",
       "One funded reset allowed per account",
     ],
     eligibility:
-      "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $200 or more.",
+      "Payout Eligibility: To be eligible for a payout, traders must have at least 5 Winning Days, each with a profit of $200 or more. Advanced is designed to offer a faster and lower-friction path to funded status, including no activation fee and no consistency requirement. Because of that structure, Advanced carries a more conservative payout cap.",
   },
   {
     name: "Builder Plan",


### PR DESCRIPTION
## Summary
Updated pricing information and payout cycle caps across the Pricing, Rules, and FAQ pages to reflect new plan structures. Standard plan now has a higher payout cap ($3,000) while Advanced plan has a more conservative cap ($2,000), with corresponding description updates to explain the trade-offs.

## Changes

- **Pricing.tsx**
  - Updated Standard plan description to highlight higher payout cap ($3,000 per cycle) and larger payout ceiling
  - Updated Advanced plan description to emphasize faster path to funded status with no activation fee, but more conservative payout cap ($2,000 per cycle)
  - Corrected payout cap values in pricing comparison table: Standard $5,000 → $3,000, Advanced $3,500 → $2,000

- **Rules.tsx**
  - Added explicit payout cycle maximums to plan rules: Standard "5-day payout cycles — maximum $3,000 per eligible payout cycle", Advanced "5-day payout cycles — maximum $2,000 per eligible payout cycle"
  - Enhanced Standard plan eligibility text to explain it's designed for traders wanting a larger payout ceiling
  - Enhanced Advanced plan eligibility text to explain its lower-friction structure and conservative payout cap

- **FAQ.tsx**
  - Updated payout FAQ answer to reflect new caps: Standard $5,000 → $3,000, Advanced $3,500 → $2,000

## Implementation Details
All changes maintain consistency across the three pages that display pricing and plan information. The updates clarify the positioning of each plan: Standard as the higher-payout option with more structure, and Advanced as the faster, lower-friction option with a more conservative payout limit.

https://claude.ai/code/session_015Ay7Es5ye3zRBouvh5gVTa