### PR TITLE
Wire reset + activation to account-bound ypf-ref checkout URLs

### DIFF
--- a/src/components/dashboard/ResetAccountModal.tsx
+++ b/src/components/dashboard/ResetAccountModal.tsx
@@ -1,3 +1,5 @@
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -7,6 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useCheckoutUrl } from "@/hooks/useTrading";
 
 // =============================================================================
 // Reset Account modal (shared by the Accounts page + the dashboard)
@@ -158,6 +161,8 @@ const getResetInfo = (
 // ---------------------------------------------------------------------------
 
 export interface ResetAccountTarget {
+  /** DF account id — used to mint an account-bound `ypf-ref` checkout URL. */
+  accountId: string;
   planType: string;
   accountSizeUsd: number;
   isFunded: boolean;
@@ -182,10 +187,23 @@ const ResetAccountModal = ({
     ? getResetInfo(account.planType, account.accountSizeUsd, account.isFunded)
     : null;
 
+  // The reset checkout URL is minted server-side with a fresh, account-bound
+  // `ypf-ref` (so the purchase reliably attaches to THIS account). `resetInfo`
+  // is used only for the pricing preview.
+  const checkoutMutation = useCheckoutUrl({
+    onSuccess: (res) => {
+      window.location.href = res.data.url;
+    },
+    onError: (err) => {
+      toast.error(
+        err.message || "Couldn't start the reset checkout. Please try again.",
+      );
+    },
+  });
+
   const handleReset = () => {
-    if (resetInfo?.checkoutUrl) {
-      window.location.href = resetInfo.checkoutUrl;
-    }
+    if (!account?.accountId) return;
+    checkoutMutation.mutate({ accountId: account.accountId, purpose: "reset" });
   };
 
   return (
@@ -238,11 +256,25 @@ const ResetAccountModal = ({
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="gap-2 sm:gap-2">
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={checkoutMutation.isPending}
+          >
             Cancel
           </Button>
-          <Button onClick={handleReset} disabled={!resetInfo}>
-            Continue to Reset
+          <Button
+            onClick={handleReset}
+            disabled={!resetInfo || !account?.accountId || checkoutMutation.isPending}
+          >
+            {checkoutMutation.isPending ? (
+              <>
+                <Loader2 size={14} className="mr-2 animate-spin" />
+                Preparing…
+              </>
+            ) : (
+              "Continue to Reset"
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/hooks/useTrading.ts
+++ b/src/hooks/useTrading.ts
@@ -26,6 +26,7 @@ import type {
   Trade,
   AccountReport,
   PlatformUrlResult,
+  CheckoutUrlResult,
   LiveOption,
   ReportRange,
 } from '@/types/trading';
@@ -234,3 +235,29 @@ export const useUpgradeAccount = (
     },
   });
 };
+
+/**
+ * Mint an account-bound WooCommerce checkout URL (reset or activation). The
+ * backend mints a fresh 5-min `ypf-ref` bound to the account, so the caller
+ * should redirect to the returned URL immediately. Read-only server-side (no
+ * cache to invalidate).
+ */
+export interface CheckoutUrlVars {
+  accountId: string;
+  purpose: 'reset' | 'activation';
+}
+
+export const useCheckoutUrl = (
+  options?: UseMutationOptions<
+    ApiResponse<CheckoutUrlResult>,
+    ApiError,
+    CheckoutUrlVars
+  >,
+) =>
+  useMutation<ApiResponse<CheckoutUrlResult>, ApiError, CheckoutUrlVars>({
+    mutationFn: ({ accountId, purpose }: CheckoutUrlVars) =>
+      purpose === 'reset'
+        ? tradingService.resetCheckoutUrl(accountId)
+        : tradingService.activationCheckoutUrl(accountId),
+    ...options,
+  });

--- a/src/pages/dashboard/DashboardAccounts.tsx
+++ b/src/pages/dashboard/DashboardAccounts.tsx
@@ -389,6 +389,7 @@ const DashboardAccounts = () => {
 
   const openReset = (account: AccountView) => {
     setResetTarget({
+      accountId: account.id,
       planType: account.planType,
       accountSizeUsd: account.accountSizeUsd,
       isFunded: account.stage === "Funded",

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -36,7 +36,12 @@ import {
 } from "@/lib/activation";
 import { Button } from "@/components/ui/button";
 import ScrollReveal from "@/components/ui/ScrollReveal";
-import { useTradingAccounts, useLiveAccount, tradingKeys } from "@/hooks/useTrading";
+import {
+  useTradingAccounts,
+  useLiveAccount,
+  useCheckoutUrl,
+  tradingKeys,
+} from "@/hooks/useTrading";
 import { useAccountView } from "@/hooks/useAccountView";
 import { useSelectedAccount } from "@/hooks/useSelectedAccount";
 import { buildChartData } from "@/lib/chartData";
@@ -94,6 +99,27 @@ const DashboardHome = () => {
   const activationUrl = accountData
     ? standardActivationUrl(accountData.plan, accountData.size)
     : null;
+
+  // Standard activation checkout is minted server-side with an account-bound
+  // `ypf-ref` (so the $80 purchase attaches to THIS account), then we redirect.
+  const activationMutation = useCheckoutUrl({
+    onSuccess: (res) => {
+      window.location.href = res.data.url;
+    },
+    onError: (err) => {
+      toast.error(
+        err.message || "Couldn't start activation checkout. Please try again.",
+      );
+    },
+  });
+
+  const handleActivate = () => {
+    if (!selectedAccount) return;
+    activationMutation.mutate({
+      accountId: selectedAccount,
+      purpose: "activation",
+    });
+  };
 
   const chartData = useMemo(() => {
     if (!accountData) return [];
@@ -182,12 +208,15 @@ const DashboardHome = () => {
                     // Standard plans pay an $80 activation fee on the YPF store.
                     <Button
                       size="sm"
-                      onClick={() =>
-                        window.open(activationUrl, "_blank", "noopener,noreferrer")
-                      }
+                      onClick={handleActivate}
+                      disabled={activationMutation.isPending}
                       className="btn-gradient-animated text-primary-foreground"
                     >
-                      <ArrowUpCircle size={14} className="mr-2" />
+                      {activationMutation.isPending ? (
+                        <Loader2 size={14} className="mr-2 animate-spin" />
+                      ) : (
+                        <ArrowUpCircle size={14} className="mr-2" />
+                      )}
                       Activate Account – ${STANDARD_ACTIVATION_FEE_USD}
                     </Button>
                   ) : (
@@ -354,8 +383,9 @@ const DashboardHome = () => {
 
       <ResetAccountModal
         account={
-          accountData
+          accountData && selectedAccount
             ? {
+                accountId: selectedAccount,
                 planType: accountData.plan,
                 accountSizeUsd: accountData.size,
                 isFunded: accountData.stage === "Funded",

--- a/src/services/trading.ts
+++ b/src/services/trading.ts
@@ -19,6 +19,7 @@ import type {
   Trade,
   AccountReport,
   PlatformUrlResult,
+  CheckoutUrlResult,
   LiveOption,
   ReportRange,
 } from '@/types/trading';
@@ -88,6 +89,26 @@ export const tradingService = {
    */
   upgradeAccount: (id: string): Promise<ApiResponse<LiveSnapshot>> =>
     apiClient.post<ApiResponse<LiveSnapshot>>(`/trading/accounts/${id}/upgrade`),
+
+  /**
+   * Mint an account-bound WooCommerce RESET checkout URL (carries a fresh,
+   * 5-min `ypf-ref` so the purchase binds to THIS account).
+   * POST /v1/trading/accounts/:id/reset-checkout
+   */
+  resetCheckoutUrl: (id: string): Promise<ApiResponse<CheckoutUrlResult>> =>
+    apiClient.post<ApiResponse<CheckoutUrlResult>>(
+      `/trading/accounts/${id}/reset-checkout`,
+    ),
+
+  /**
+   * Mint an account-bound WooCommerce ACTIVATION checkout URL (Standard $80
+   * fee), same `ypf-ref` binding.
+   * POST /v1/trading/accounts/:id/activation-checkout
+   */
+  activationCheckoutUrl: (id: string): Promise<ApiResponse<CheckoutUrlResult>> =>
+    apiClient.post<ApiResponse<CheckoutUrlResult>>(
+      `/trading/accounts/${id}/activation-checkout`,
+    ),
 
   /**
    * One-time SSO URL into the trading platform's web dashboard.

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -169,6 +169,11 @@ export interface PlatformUrlResult {
   url: string;
 }
 
+/** Account-bound WooCommerce checkout URL (reset / activation) with a minted ypf-ref. */
+export interface CheckoutUrlResult {
+  url: string;
+}
+
 // ---------------------------------------------------------------------------
 // Query params
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Wires the **Reset** and **Standard $80 Activation** flows to the new backend endpoints that mint an account-bound `ypf-ref` checkout URL. Previously these buttons redirected to hardcoded WooCommerce product permalinks that bound by email + size only — unreliable when a trader has multiple same-size accounts, and the source of the checkout→cart redirect loop for unbound sessions. Now the checkout URL is minted server-side with a fresh, account-specific `ypf-ref`, so the purchase reliably attaches to the exact account.

## Changes

- **`services/trading.ts`** — `resetCheckoutUrl(id)` / `activationCheckoutUrl(id)` → `POST /trading/accounts/:id/{reset,activation}-checkout` returning `{ url }` (+ `CheckoutUrlResult` type).
- **`hooks/useTrading.ts`** — `useCheckoutUrl({ accountId, purpose })` mutation.
- **`ResetAccountModal`** — "Continue to Reset" now mints the account-bound URL (needs the new `accountId` on `ResetAccountTarget`), shows a "Preparing…" spinner, and toasts on failure instead of jumping to a hardcoded permalink. Pricing preview unchanged.
- **`DashboardHome`** — the "Activate Account – $80" button mints the activation URL (with spinner); threads `accountId` into the reset modal target.
- **`DashboardAccounts`** — threads `accountId` into the reset target.

## Verification

`npm run build` clean (11 routes prerender) · lint at repo baseline (6 err / 23 warn, all pre-existing).

Requires DF-Backend **#48** (the `reset-checkout` / `activation-checkout` endpoints) — merge/deploy that first.
