### PR TITLE
Gate reset once per account + route Trade tab to hosted platform

### DIFF
--- a/src/data/mockDashboardData.ts
+++ b/src/data/mockDashboardData.ts
@@ -80,6 +80,9 @@ export interface AccountData {
   // True when the account hit its profit target and YPF will allow an
   // eval → funded upgrade (drives the "Upgrade to Funded" CTA).
   canUpgrade?: boolean;
+  // True once the account has already been reset (a reset is allowed only once
+  // per account) — hides the "Reset Account" CTA.
+  alreadyReset?: boolean;
 }
 
 // Generate random but realistic equity curves

--- a/src/lib/tradingAdapter.ts
+++ b/src/lib/tradingAdapter.ts
@@ -433,6 +433,8 @@ export const adaptAccountView = (
     ...(live?.isLevelUpReached && !live.upgradeRequestDate
       ? { canUpgrade: true }
       : {}),
+    // A reset can be bought only once per account; hide the CTA once used.
+    ...(live?.isResetBefore ? { alreadyReset: true } : {}),
   };
 };
 

--- a/src/pages/dashboard/DashboardHome.tsx
+++ b/src/pages/dashboard/DashboardHome.tsx
@@ -229,17 +229,18 @@ const DashboardHome = () => {
                       Upgrade to Funded
                     </Button>
                   ))}
-                {accountData?.status === "Violated" && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setResetOpen(true)}
-                    className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70"
-                  >
-                    <RotateCcw size={14} className="mr-2" />
-                    Reset Account
-                  </Button>
-                )}
+                {accountData?.status === "Violated" &&
+                  !accountData?.alreadyReset && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setResetOpen(true)}
+                      className="border-border/40 text-muted-foreground hover:text-foreground hover:border-border/70"
+                    >
+                      <RotateCcw size={14} className="mr-2" />
+                      Reset Account
+                    </Button>
+                  )}
               </>
             )}
             {/* New Challenge button — always visible in top-right */}

--- a/src/pages/dashboard/DashboardTrade.tsx
+++ b/src/pages/dashboard/DashboardTrade.tsx
@@ -1,21 +1,18 @@
-import { Loader2, AlertCircle, ExternalLink } from 'lucide-react';
+import { Loader2, ExternalLink } from 'lucide-react';
 import ScrollReveal from '@/components/ui/ScrollReveal';
 import OpenPlatformButton from '@/components/dashboard/OpenPlatformButton';
-import { useTradingAccounts, useIframeUrl } from '@/hooks/useTrading';
+import { useTradingAccounts } from '@/hooks/useTrading';
+import deepchartsLogo from '@/assets/deepcharts-logo.png';
 
 const DashboardTrade = () => {
   const accountsQ = useTradingAccounts();
   const accounts = accountsQ.data?.data ?? [];
   const hasAccounts = accounts.length > 0;
 
-  // The embed is the full Volumetrica web platform, which has its own built-in
-  // account switcher — so we mint a single user-scoped session and let the
-  // trader change accounts inside the platform itself. (A DF-side dropdown
-  // can't reliably re-scope the embed, since the minted session is keyed to the
-  // trader, not an individual account.)
-  const iframeQ = useIframeUrl(undefined, { enabled: hasAccounts });
-  const iframeUrl = iframeQ.data?.data.url;
-
+  // Trading runs on the hosted Volumetrica/DeepCharts platform, where the trader
+  // self-authenticates (email + per-account password shown on the dashboard).
+  // We launch it in a new tab rather than embedding: the hosted login can't be
+  // iframed, and our Volumetrica session-mint isn't available for trader orgs.
   return (
     <div className="space-y-6 pt-16 lg:pt-0">
       <ScrollReveal>
@@ -23,65 +20,50 @@ const DashboardTrade = () => {
           <div>
             <h1 className="text-2xl font-bold text-foreground">Trade</h1>
             <p className="text-muted-foreground mt-1">
-              Live trading via DeepCharts, embedded right here. Switch between
-              your accounts directly inside the platform.
+              Launch the full trading platform to place and manage your orders.
             </p>
           </div>
           <OpenPlatformButton variant="outline" size="default" />
         </div>
       </ScrollReveal>
 
-      {/* Loading list */}
       {accountsQ.isLoading && (
         <div className="flex items-center justify-center py-20 text-muted-foreground">
           <Loader2 className="animate-spin mr-2" size={18} /> Loading…
         </div>
       )}
 
-      {/* No accounts */}
       {!accountsQ.isLoading && !hasAccounts && (
         <div className="rounded-2xl border border-border/30 bg-card/50 p-8 text-center text-muted-foreground">
           You don't have any trading accounts yet.
         </div>
       )}
 
-      {/* iFrame */}
-      {hasAccounts && iframeQ.isLoading && (
-        <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm flex items-center justify-center min-h-[600px] text-muted-foreground">
-          <Loader2 className="animate-spin mr-2" size={18} /> Connecting to
-          trading platform…
-        </div>
-      )}
-
-      {hasAccounts && iframeQ.isError && (
-        <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 flex items-start gap-3">
-          <AlertCircle className="text-destructive shrink-0 mt-0.5" size={20} />
-          <div className="flex-1">
-            <p className="font-medium text-foreground">
-              Failed to load trading platform
-            </p>
-            <p className="text-sm text-muted-foreground mt-1">
-              {iframeQ.error?.message ??
-                'Try the "DeepCharts" button to launch in a new tab.'}
+      {!accountsQ.isLoading && hasAccounts && (
+        <ScrollReveal>
+          <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm p-8 sm:p-12 flex flex-col items-center text-center min-h-[420px] justify-center gap-6">
+            <img
+              src={deepchartsLogo}
+              alt="DeepCharts"
+              className="h-10 w-auto object-contain opacity-90"
+            />
+            <div className="space-y-2 max-w-md">
+              <h2 className="text-xl font-semibold text-foreground">
+                Trade on the DeepCharts platform
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Your live charts, order entry, and positions open in the full
+                trading platform. Sign in with the login and password from your
+                account credentials, then pick the account you want to trade.
+              </p>
+            </div>
+            <OpenPlatformButton variant="default" size="lg" />
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <ExternalLink size={12} />
+              Opens in a new tab
             </p>
           </div>
-        </div>
-      )}
-
-      {hasAccounts && iframeUrl && (
-        <div className="rounded-2xl border border-border/30 bg-card/50 backdrop-blur-sm overflow-hidden">
-          <iframe
-            src={iframeUrl}
-            title="Trading Platform"
-            className="w-full h-[calc(100vh-220px)] min-h-[600px] border-0"
-            allow="clipboard-read; clipboard-write"
-            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-          />
-          <div className="flex items-center justify-end gap-2 p-2 border-t border-border/30 text-xs text-muted-foreground">
-            <ExternalLink size={12} />
-            <span>Embedded via DeepCharts</span>
-          </div>
-        </div>
+        </ScrollReveal>
       )}
     </div>
   );

--- a/src/types/trading.ts
+++ b/src/types/trading.ts
@@ -81,6 +81,9 @@ export interface LiveSnapshot {
   isLevelUpReached?: boolean;
   // ISO timestamp once an upgrade has been requested (absent = none pending)
   upgradeRequestDate?: string;
+  // True once the account has been reset — a reset may be bought only once per
+  // account, so this hides the reset CTA (backend also blocks a second reset).
+  isResetBefore?: boolean;
   // Drawdown metrics
   drawDown?: number;
   maxDrawDown?: number;


### PR DESCRIPTION
## Two dashboard fixes: reset-once gating + working Trade tab

> **Stacked on DF-Frontend #205** (`ypfRefCheckoutBinding`) — merge #205 first; the base will retarget to `main` after. Pairs with DF-Backend #51 (reset gate) and the already-merged checkout PRs.

### 1. Reset allowed only once per account
YPF exposes a per-account `isResetBefore` flag. Surfaced it on `LiveSnapshot` → `AccountData.alreadyReset` (adapter), and the DashboardHome "Reset Account" CTA is hidden once the account has been reset. Backend (DF-Backend #51) is the hard gate — it rejects a second reset with a clear message, which the inactive-accounts reset modal surfaces on click. Applies in both eval and funded phases.

### 2. Trade tab → hosted platform (embed was broken)
The in-app Volumetrica iframe can't load: YPF isn't populating `extraValues.VolumetricaUserId` on accounts (all empty), so the SSO mint 400s — and even when present the webApp mint 404s (our Propsite key is wrong-org). The hosted portal works fine (`/Identity/Account/Login` → 200). Replaced the broken iframe on `DashboardTrade` with a clean launch panel + "Launch Platform" CTA (opens the hosted platform in a new tab, where the trader self-authenticates and picks their account) — same mechanism as the existing Open Platform button.

## Verified
`npm run build` clean (11 routes prerender) · lint at repo baseline (6 err / 23 warn, all pre-existing).

Note: the standalone Volumetrica embed remains blocked upstream (needs YPF to populate `VolumetricaUserId` + a trader-org key) — this routes around it rather than fixing the embed itself.
