### PR TITLE
Remove Trustpilot review widget from homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,10 +29,6 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image" content="https://www.dynastyfuturesdyn.com/og-image.png?v=20260509" />
 
-    <!-- TrustBox script -->
-    <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
-    <!-- End TrustBox script -->
-
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -7,38 +7,6 @@ import logo from "@/assets/DF_Logo.png";
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 import { useScrollProgress } from "@/hooks/useScrollProgress";
 
-declare global {
-  interface Window {
-    Trustpilot?: { loadFromElement: (el: Element, reinitialize: boolean) => void };
-  }
-}
-
-const TrustpilotWidget = () => {
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (ref.current && window.Trustpilot) {
-      window.Trustpilot.loadFromElement(ref.current, true);
-    }
-  }, []);
-
-  return (
-    <div
-      ref={ref}
-      className="trustpilot-widget"
-      data-locale="en-US"
-      data-template-id="56278e9abfbbba0bdcd568bc"
-      data-businessunit-id="6a2b945f8f56de259c00cd76"
-      data-style-height="52px"
-      data-style-width="100%"
-      data-token="7ef7d5f6-8481-4d7d-97e8-cd139cf18ebbb"
-    >
-      <a href="https://www.trustpilot.com/review/dynastyfuturesdyn.com" target="_blank" rel="noopener">
-        Trustpilot
-      </a>
-    </div>
-  );
-};
 
 const Hero = () => {
   const sectionRef = useRef<HTMLElement>(null);
@@ -204,12 +172,6 @@ const Hero = () => {
               </Button>
             </div>
 
-            {/* Official Trustpilot Review Collector widget */}
-            <div className="flex justify-center lg:justify-start mt-3 animate-fade-in" style={{ animationDelay: "0.45s" }}>
-              <div className="trustpilot-hero-widget">
-                <TrustpilotWidget />
-              </div>
-            </div>
           </div>
 
           {/* Right content - Trading Dashboard Mock */}

--- a/src/index.css
+++ b/src/index.css
@@ -802,20 +802,3 @@
     }
   }
 }
-
-.trustpilot-hero-widget {
-  max-width: 320px;
-  width: 100%;
-  height: 52px;
-  margin-top: 12px;
-  background: transparent;
-  border-radius: 0;
-  box-shadow: none;
-  padding: 0;
-}
-
-@media (min-width: 769px) {
-  .trustpilot-hero-widget {
-    margin-left: -12px;
-  }
-}


### PR DESCRIPTION
## Summary

- Removed `TrustpilotWidget` component and its `window.Trustpilot` global declaration from `Hero.tsx`
- Removed the widget's render call (the `"Review us on Trustpilot"` CTA block) from the hero JSX
- Removed `.trustpilot-hero-widget` CSS rules from `index.css`
- Removed the Trustpilot bootstrap script tag from `index.html`

No other Trustpilot references (e.g. elsewhere on the site) were touched. The hero headline, buttons, chart card, countdown, navbar, and overall layout are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QB9MhG9fYdz5Xtst3e1a1G)_