### PR TITLE
Hide LinkedIn links from About page (founders & tech team)

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -148,15 +148,6 @@ const FounderCard = ({
                 — {name}
               </footer>
             </blockquote>
-            <a
-              href={linkedin}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
-            >
-              {linkedInIcon}
-              <span>LinkedIn Profile</span>
-            </a>
           </div>
         </div>
       </div>
@@ -528,7 +519,7 @@ const About = () => {
             <div className="grid md:grid-cols-2 gap-6 max-w-4xl mx-auto">
               <ScrollReveal delay={0}>
                 <div className="bg-gradient-card rounded-2xl border border-border/50 p-8 h-full">
-                  <div className="mb-6">
+                  <div>
                     <h3 className="font-display text-xl font-bold text-foreground mb-1">
                       Justin Perez
                     </h3>
@@ -536,23 +527,12 @@ const About = () => {
                       Co-Lead Developer
                     </p>
                   </div>
-                  <a
-                    href="https://linkedin.com/in/justindperez"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
-                  >
-                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                    </svg>
-                    <span>Connect on LinkedIn</span>
-                  </a>
                 </div>
               </ScrollReveal>
 
               <ScrollReveal delay={100}>
                 <div className="bg-gradient-card rounded-2xl border border-border/50 p-8 h-full">
-                  <div className="mb-6">
+                  <div>
                     <h3 className="font-display text-xl font-bold text-foreground mb-1">
                       William Kelly
                     </h3>
@@ -560,17 +540,6 @@ const About = () => {
                       Co-Lead Developer
                     </p>
                   </div>
-                  <a
-                    href="https://www.linkedin.com/in/william-kelly-iii-748409194"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-primary transition-colors"
-                  >
-                    <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-                    </svg>
-                    <span>Connect on LinkedIn</span>
-                  </a>
                 </div>
               </ScrollReveal>
             </div>


### PR DESCRIPTION
## Summary

- Removes the "LinkedIn Profile" link from founder cards (visible in the expanded bio section)
- Removes the "Connect on LinkedIn" links from both technical team member cards (Justin Perez, William Kelly)
- The underlying `linkedin` field values in the founders data array are **preserved** so links can be re-enabled without data loss
- Footer LinkedIn links are untouched
- No layout, spacing, bio, photo, or card structure changes beyond cleaning up the removed anchor elements

---
_Generated by [Claude Code](https://claude.ai/code/session_01JHs5EsWUxzfK6i9PZkfQMA)_