### PR TITLE
Replace countdown banner with Dynasty Futures 2.0 announcement

### DIFF
--- a/src/components/home/LaunchCountdown.tsx
+++ b/src/components/home/LaunchCountdown.tsx
@@ -1,86 +1,64 @@
-import { useState, useEffect } from 'react';
-
-// Target: 2026-06-29T00:00:00 America/Denver (Mountain Time)
-// Mountain Time is UTC-6 in summer (MDT). June 29 00:00 MDT = June 29 06:00 UTC
-const LAUNCH_UTC_MS = Date.UTC(2026, 5, 29, 6, 0, 0); // months are 0-indexed
-
-interface TimeLeft {
-  days: number;
-  hours: number;
-  minutes: number;
-  seconds: number;
-}
-
-function getTimeLeft(): TimeLeft | null {
-  const diff = LAUNCH_UTC_MS - Date.now();
-  if (diff <= 0) return null;
-  return {
-    days: Math.floor(diff / (1000 * 60 * 60 * 24)),
-    hours: Math.floor((diff / (1000 * 60 * 60)) % 24),
-    minutes: Math.floor((diff / (1000 * 60)) % 60),
-    seconds: Math.floor((diff / 1000) % 60),
-  };
-}
-
-function pad(n: number) {
-  return String(n).padStart(2, '0');
-}
-
 const LaunchCountdown = () => {
-  const [timeLeft, setTimeLeft] = useState<TimeLeft | null>(getTimeLeft);
-
-  useEffect(() => {
-    const id = setInterval(() => {
-      setTimeLeft(getTimeLeft());
-    }, 1000);
-    return () => clearInterval(id);
-  }, []);
-
   return (
     <div className="flex justify-center px-4 mt-16 sm:mt-20 mb-6">
       <div
-        className="glass-card border border-gold/30 rounded-xl px-6 py-4 text-center"
+        className="glass-card border border-gold/30 rounded-xl px-6 py-5 text-center"
         style={{
           maxWidth: '580px',
           width: '100%',
           boxShadow: '0 0 18px 2px rgba(212,175,55,0.12), 0 2px 16px rgba(0,0,0,0.4)',
         }}
       >
-        {timeLeft ? (
-          <>
-            <p className="text-xs uppercase tracking-widest text-white/60 mb-3 leading-none">
-              <span className="text-gold font-semibold">Dynasty Futures</span>{' '}
-              <span className="text-white/80">goes live in</span>
+        <div className="flex items-start gap-3 text-left">
+          <div className="mt-0.5 shrink-0">
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-hidden="true"
+            >
+              <path
+                d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+                stroke="url(#gold-grad)"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <defs>
+                <linearGradient id="gold-grad" x1="2" y1="2" x2="22" y2="22" gradientUnits="userSpaceOnUse">
+                  <stop stopColor="#D4AF37" />
+                  <stop offset="1" stopColor="#F5D77E" />
+                </linearGradient>
+              </defs>
+            </svg>
+          </div>
+          <div>
+            <p className="text-base sm:text-lg font-bold leading-snug mb-1.5">
+              <span
+                style={{
+                  background: 'linear-gradient(90deg, #D4AF37 0%, #F5D77E 50%, #D4AF37 100%)',
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                  backgroundClip: 'text',
+                }}
+              >
+                Dynasty Futures 2.0
+              </span>{' '}
+              <span className="text-white">is Coming Soon</span>
             </p>
-            <div className="flex items-center justify-center gap-3 sm:gap-5">
-              {[
-                { value: timeLeft.days, label: 'Days' },
-                { value: timeLeft.hours, label: 'Hours' },
-                { value: timeLeft.minutes, label: 'Minutes' },
-                { value: timeLeft.seconds, label: 'Seconds' },
-              ].map(({ value, label }, i) => (
-                <div key={label} className="flex items-center gap-3 sm:gap-5">
-                  {i > 0 && (
-                    <span className="text-gold/40 text-lg font-light select-none">|</span>
-                  )}
-                  <div className="flex flex-col items-center">
-                    <span className="text-2xl sm:text-3xl font-bold text-white tabular-nums leading-none">
-                      {pad(value)}
-                    </span>
-                    <span className="text-[10px] uppercase tracking-widest text-gold/70 mt-1 leading-none">
-                      {label}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </>
-        ) : (
-          <p className="text-base sm:text-lg font-semibold">
-            <span className="text-gold">Dynasty Futures</span>{' '}
-            <span className="text-white">is Live</span>
-          </p>
-        )}
+            <p className="text-sm text-white/70 leading-relaxed mb-2.5">
+              We're currently preparing the next generation of Dynasty Futures with new platform
+              integrations, major improvements, and an enhanced trading experience. Account
+              purchases are temporarily unavailable while we complete development.
+            </p>
+            <p className="text-xs text-white/50 leading-relaxed">
+              Our team will announce when Dynasty Futures 2.0 is ready to launch. Stay tuned for
+              upcoming announcements.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Removes the live countdown timer from the homepage banner entirely
- Replaces it with a static announcement communicating that Dynasty Futures 2.0 is actively in development
- Preserves all existing visual treatment: glass-card, gold glow, border, rounded corners, and responsive layout

## Changes

**`src/components/home/LaunchCountdown.tsx`**
- Removed all countdown state, interval, and timer logic
- Added a layered SVG icon with the Dynasty gold gradient
- Headline: "Dynasty Futures 2.0" rendered with the signature gold gradient; "is Coming Soon" in white
- Subheading explains that platform integrations, major improvements, and an enhanced trading experience are in progress, and that account purchases are temporarily unavailable
- Status line notes that announcements will be made when 2.0 is ready to launch
- No buttons, no countdown, no refund/payout language
- Fully responsive on desktop and mobile

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mq5pj6KT47jCyMRW7nPpEw)_